### PR TITLE
Use the schema files in the repo when testing remote schema files

### DIFF
--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -16,6 +16,7 @@
 
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 import requests.exceptions
@@ -32,9 +33,14 @@ class TestSchemaRetrieval:
     def test_default_schema(self):
         "Test the basic functioning of retrieving default schema files."
 
-        # We only assert that we have retrieved some non-empty files here. This is because we want to decouple the
-        # maintenance of schema files in production with the library development. These files likely would change more
-        # regularly than the library.
+        # We only assert that we have retrieved some non-empty files in this test. This is because we want to decouple
+        # the maintenance of schema files in production with the library development. These files likely would change
+        # more regularly than the library. For this reason, we also verify the default schema URLs are also valid https
+        # links.
+        assert urlparse(DatasetSchema.DEFAULT_SCHEMA_URL).scheme == 'https'
+        assert urlparse(FormatSchema.DEFAULT_SCHEMA_URL).scheme == 'https'
+        assert urlparse(LicenseSchema.DEFAULT_SCHEMA_URL).scheme == 'https'
+
         # We only assert them not being None here just in case the server returns zero-length files.
         assert retrieve_schema_file(DatasetSchema.DEFAULT_SCHEMA_URL) is not None
         assert retrieve_schema_file(FormatSchema.DEFAULT_SCHEMA_URL) is not None

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -33,9 +33,10 @@ class TestSchemaRetrieval:
         # We only assert that we have retrieved some non-empty files here. This is because we want to decouple the
         # maintenance of schema files in production with the library development. These files likely would change more
         # regularly than the library.
-        assert retrieve_schema_file(DatasetSchema.DEFAULT_SCHEMA_URL)
-        assert retrieve_schema_file(FormatSchema.DEFAULT_SCHEMA_URL)
-        assert retrieve_schema_file(LicenseSchema.DEFAULT_SCHEMA_URL)
+        # We only assert them not being None here just in case the server returns zero-length files.
+        assert retrieve_schema_file(DatasetSchema.DEFAULT_SCHEMA_URL) is not None
+        assert retrieve_schema_file(FormatSchema.DEFAULT_SCHEMA_URL) is not None
+        assert retrieve_schema_file(LicenseSchema.DEFAULT_SCHEMA_URL) is not None
 
     def test_custom_schema_local(self):
         "Test retrieving user-specified local schema files."

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -26,8 +26,7 @@ from pydax.schema import DatasetSchema, FormatSchema, LicenseSchema
 class TestSchemaRetrieval:
     "Test schema retrieval."
 
-    # We allow this to fail because the default remote might be down but it's not this library's issue.
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="default remote might be down but it's not this library's issue", raises=ConnectionError)
     def test_default_schema(self):
         "Test the basic functioning of retrieving default schema files."
 

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -18,6 +18,7 @@ import os
 from pathlib import Path
 
 import pytest
+import requests.exceptions
 
 from pydax._schema_retrieval import retrieve_schema_file
 from pydax.schema import DatasetSchema, FormatSchema, LicenseSchema
@@ -26,7 +27,8 @@ from pydax.schema import DatasetSchema, FormatSchema, LicenseSchema
 class TestSchemaRetrieval:
     "Test schema retrieval."
 
-    @pytest.mark.xfail(reason="default remote might be down but it's not this library's issue", raises=ConnectionError)
+    @pytest.mark.xfail(reason="default remote might be down but it's not this library's issue",
+                       raises=requests.exceptions.ConnectionError)
     def test_default_schema(self):
         "Test the basic functioning of retrieving default schema files."
 

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -16,35 +16,14 @@
 
 import os
 from pathlib import Path
-from urllib.parse import urlparse
 
 import pytest
-import requests.exceptions
 
 from pydax._schema_retrieval import retrieve_schema_file
-from pydax.schema import DatasetSchema, FormatSchema, LicenseSchema
 
 
 class TestSchemaRetrieval:
     "Test schema retrieval."
-
-    @pytest.mark.xfail(reason="default remote might be down but it's not this library's issue",
-                       raises=requests.exceptions.ConnectionError)
-    def test_default_schema(self):
-        "Test the basic functioning of retrieving default schema files."
-
-        # We only assert that we have retrieved some non-empty files in this test. This is because we want to decouple
-        # the maintenance of schema files in production with the library development. These files likely would change
-        # more regularly than the library. For this reason, we also verify the default schema URLs are also valid https
-        # links.
-        assert urlparse(DatasetSchema.DEFAULT_SCHEMA_URL).scheme == 'https'
-        assert urlparse(FormatSchema.DEFAULT_SCHEMA_URL).scheme == 'https'
-        assert urlparse(LicenseSchema.DEFAULT_SCHEMA_URL).scheme == 'https'
-
-        # We only assert them not being None here just in case the server returns zero-length files.
-        assert retrieve_schema_file(DatasetSchema.DEFAULT_SCHEMA_URL) is not None
-        assert retrieve_schema_file(FormatSchema.DEFAULT_SCHEMA_URL) is not None
-        assert retrieve_schema_file(LicenseSchema.DEFAULT_SCHEMA_URL) is not None
 
     def test_custom_schema_local(self):
         "Test retrieving user-specified local schema files."

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -26,20 +26,20 @@ from pydax.schema import DatasetSchema, FormatSchema, LicenseSchema
 class TestSchemaRetrieval:
     "Test schema retrieval."
 
+    # We allow this to fail because the default remote might be down but it's not this library's issue.
+    @pytest.mark.xfail
     def test_default_schema(self):
         "Test the basic functioning of retrieving default schema files."
 
-        # We assert they are identical to the test schema files for now, because we don't host them on any websites.
-        # Probably this will change in the future.
-        assert retrieve_schema_file(DatasetSchema.DEFAULT_SCHEMA_URL) == \
-            Path('tests/schemata/datasets.yaml').read_text()
-        assert retrieve_schema_file(FormatSchema.DEFAULT_SCHEMA_URL) == \
-            Path('tests/schemata/formats.yaml').read_text()
-        assert retrieve_schema_file(LicenseSchema.DEFAULT_SCHEMA_URL) == \
-            Path('tests/schemata/licenses.yaml').read_text()
+        # We only assert that we have retrieved some non-empty files here. This is because we want to decouple the
+        # maintenance of schema files in production with the library development. These files likely would change more
+        # regularly than the library.
+        assert retrieve_schema_file(DatasetSchema.DEFAULT_SCHEMA_URL)
+        assert retrieve_schema_file(FormatSchema.DEFAULT_SCHEMA_URL)
+        assert retrieve_schema_file(LicenseSchema.DEFAULT_SCHEMA_URL)
 
-    def test_custom_schema(self):
-        "Test retrieving user-specified schema files."
+    def test_custom_schema_local(self):
+        "Test retrieving user-specified local schema files."
 
         # We assert they are identical to the test schema files for now, because we don't host them on any websites.
         # Probably this will change in the future.
@@ -47,8 +47,13 @@ class TestSchemaRetrieval:
             Path('tests/schemata/datasets.yaml').read_text()
         assert retrieve_schema_file(f'file://{os.getcwd()}/tests/schemata/formats.yaml') == \
             Path('tests/schemata/formats.yaml').read_text()
-        assert retrieve_schema_file(LicenseSchema.DEFAULT_SCHEMA_URL.replace('https://', 'http://', 1)) == \
+
+    def test_custom_schema_remote(self, http_schema_file_url):
+        "Test retrieving user-specified remote schema files."
+
+        assert retrieve_schema_file(http_schema_file_url + 'licenses.yaml') == \
             Path('tests/schemata/licenses.yaml').read_text()
+        # TODO: Add https tests here when we add stronger security measurements
 
     def test_invalid_schema(self):
         "Test retrieving user-specified invalid schema files."

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ download = True
 usedevelop = True
 deps = -rrequirements/test.txt
 commands =
-    coverage run -m pytest
+    coverage run -m pytest -v
     coverage report
 
 [testenv:pypy3]


### PR DESCRIPTION
Also reorganized the default schema URL test, which is incidental to the main purpose of this PR.