### PR TITLE
Initial minimal CSV loader implementation

### DIFF
--- a/pydax/loaders/_base.py
+++ b/pydax/loaders/_base.py
@@ -16,19 +16,21 @@
 
 from abc import ABC, abstractmethod
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from .. import _typing
+from .._schema import SchemaDict
 
 
 class Loader(ABC):
     "Base class of all loaders."
 
     @abstractmethod
-    def load(self, path: Union[_typing.PathLike, Dict[str, str]]) -> Any:
+    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: Optional[SchemaDict]) -> Any:
         """Loads from a give path or a dict of path configurations. This should must overridden when inherited.
 
         :param path: The path or path configurations of the files to be loaded.
+        :param options: Options passed to the loader.
         :return: The object representing the loaded file.
         """
         pass

--- a/pydax/loaders/_table.py
+++ b/pydax/loaders/_table.py
@@ -17,14 +17,12 @@
 "Tabular data loaders."
 
 import os
-
 from typing import Dict, Optional, Union
 
 import pandas as pd  # type: ignore
 
 from .. import _typing
 from ..schema import SchemaDict
-
 from ._base import Loader
 
 

--- a/pydax/loaders/_table.py
+++ b/pydax/loaders/_table.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2020 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"Tabular data loaders."
+
+import os
+
+from typing import Dict, Optional, Union
+
+import pandas as pd  # type: ignore
+
+from .. import _typing
+from ..schema import SchemaDict
+
+from ._base import Loader
+
+
+class CSVPandasLoader(Loader):
+
+    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: Optional[SchemaDict]) -> str:
+        """The type hint says Dict, because this loader will be handling those situations in the future, perhaps via a
+        ``IteratingLoader`` class.
+
+        :param path: The path to the CSV file.
+        :param options:
+               - ``columns`` key specifies the datatype of each column. If unspecified, then it is default.
+               - ``encoding`` key specifies the encoding of the CSV file. Defaults to UTF-8.
+        :raises TypeError: ``path`` is not a path object.
+        """
+
+        if not isinstance(path, (str, os.PathLike)):
+            # In Python 3.8, this can be done with isinstance(path, typing.get_args(_typing.PathLike))
+            raise TypeError(f'Unsupported path type "{type(path)}".')
+
+        if options is None:
+            options = {}
+
+        parse_dates = []
+        for column, type_ in options.get('columns', {}).items():
+            # TODO: This is very simple right now. Need consider more situations
+            if type_ == 'date':
+                # pandas has this unusual handling of date datatype. Instead of specifying as a data type of a column,
+                # we have to pass in `parse_dates`.
+                parse_dates.append(column)
+
+        return pd.read_csv(path, parse_dates=parse_dates, encoding=options.get('encoding', 'utf-8'))

--- a/pydax/loaders/table.py
+++ b/pydax/loaders/table.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2020 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from ._table import CSVPandasLoader
+
+__all__ = ('CSVPandasLoader',)

--- a/pydax/loaders/text.py
+++ b/pydax/loaders/text.py
@@ -16,18 +16,20 @@
 
 import os
 import pathlib
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 from .. import _typing
+from ..schema import SchemaDict
 from ._base import Loader
 
 
 class PlainTextLoader(Loader):
 
-    def load(self, path: Union[_typing.PathLike, Dict[str, str]]) -> str:
+    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: Optional[SchemaDict]) -> str:
         """The type hint says Dict, because this loader will be handling those situations in the future.
 
         :param path: The path to the plain text file.
+        :param options: Unused.
         """
 
         if not isinstance(path, (str, os.PathLike)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,11 @@ def gmb_schema(loaded_schemata):
 
 
 @pytest.fixture
+def noaa_jfk_schema(loaded_schemata):
+    return loaded_schemata.schemata['dataset_schema'].export_schema('datasets', 'noaa_jfk', '1.1.4')
+
+
+@pytest.fixture
 def wikitext103_schema(loaded_schemata):
     return loaded_schemata.schemata['dataset_schema'].export_schema('datasets', 'wikitext103', '1.0.1')
 
@@ -111,3 +116,13 @@ def schema_file_http_url(local_http_server) -> str:
 def downloaded_wikitext103_dataset(wikitext103_schema):
     with TemporaryDirectory() as tmp_data_dir:
         yield Dataset(wikitext103_schema, data_dir=tmp_data_dir, mode=Dataset.InitializationMode.DOWNLOAD_ONLY)
+
+
+@pytest.fixture
+def spoofed_default_url(schema_file_http_url):
+    # TODO: There should be some way for list_all_datasets() to use a different schema file URL via pydax.init(). We
+    # have this workaround using this fixture for now.
+    old_defaults = load_schemata.__kwdefaults__.copy()
+    load_schemata.__kwdefaults__['dataset_url'] = schema_file_http_url + '/datasets.yaml'
+    yield
+    load_schemata.__kwdefaults__ = old_defaults

--- a/tests/schemata/datasets.yaml
+++ b/tests/schemata/datasets.yaml
@@ -59,3 +59,24 @@ datasets:
           description: Tokens in the testing subset
           format: txt
           path: wikitext-103/wiki.test.tokens
+  noaa_jfk:
+    "1.1.4":
+      name: NOAA Weather Data – JFK Airport
+      published: 2019-09-12
+      homepage: https://developer.ibm.com/exchanges/data/all/jfk-weather-data/
+      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-noaa-weather-data-jfk-airport/1.1.4/noaa-weather-data-jfk-airport.tar.gz
+      sha512sum: e3f27a8fcc0db5289df356e3f48aef6df56236798d5b3ae3889d358489ec6609d2d797e4c4932b86016d2ce4a379ac0a0749b6fb2c293ebae4e585ea1c8422ac
+      license: cdla_sharing
+      estimated_size: 3.2M
+      description: "The NOAA JFK dataset contains 114,546 hourly observations of various local climatological variables (including visibility, temperature, wind speed and direction, humidity, dew point, and pressure). The data was collected by a NOAA weather station located at the John F. Kennedy International Airport in Queens, New York."
+      subdatasets:
+        jfk_weather_cleaned:
+          name: Cleaned JFK Weather Data
+          description: Cleaned version of the JFK weather data.
+          format:
+            id: csv
+            options:
+              encoding: 'UTF-8'
+              columns:
+                DATE: 'date'
+          path: noaa-weather-data-jfk-airport/jfk_weather_cleaned.csv

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -26,11 +26,11 @@ from pydax import init, list_all_datasets, load_dataset
 from pydax.dataset import Dataset
 
 
-def test_list_all_datasets():
+def test_list_all_datasets(spoofed_default_url):
     "Test to make sure test_list_all_datasets function returns available dataset names."
 
     datasets = list_all_datasets()
-    assert frozenset(datasets.keys()) == frozenset(['gmb', 'wikitext103'])
+    assert frozenset(datasets.keys()) == frozenset(['gmb', 'noaa_jfk', 'wikitext103'])
 
 
 class TestDataset:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -15,11 +15,14 @@
 #
 
 import pytest
+import pandas as pd
 
+from pydax.dataset import Dataset
 from pydax.loaders import Loader
 from pydax.loaders import FormatLoaderMap
 from pydax.loaders._format_loader_map import _load_data_files
 from pydax.loaders.text import PlainTextLoader
+from pydax.loaders.table import CSVPandasLoader
 
 
 class TestBaseLoader:
@@ -44,10 +47,11 @@ class TestBaseLoader:
         assert "Can't instantiate abstract class MyLoader with abstract method" in str(e.value)
 
         class MyLoader(Loader):
-            def load(self, path):
+            def load(self, path, options):
                 # Calling the parent's load() method shouldn't lead to error
-                super().load(path)
-        MyLoader().load(tmp_path)  # This line shouldn't error out even though it calls an abstract method in its parent
+                super().load(path, options)
+        # This line shouldn't error out even though it calls an abstract method in its parent
+        MyLoader().load(tmp_path, None)
 
 
 class TestFormatLoaderMap:
@@ -70,14 +74,57 @@ class TestFormatLoaderMap:
 
         assert str(e.value) == 'The format loader map does not specify a loader for format "nonsense".'
 
+    def test_load_wrong_format_type(self, tmp_path):
+        "Test loading a non-existing format."
+
+        with pytest.raises(TypeError) as e:
+            _load_data_files(0x348f, tmp_path)
+
+        assert str(e.value) == 'Parameter "fmt" must be a string or a dict, but it is of type "<class \'int\'>".'
+
 
 class TestTextLoaders:
 
-    def test_plain_text_loader(self):
+    def test_plain_text_loader_no_path(self):
         "Test PlainTextLoader when fed in with non-path."
 
         integer = 1
         with pytest.raises(TypeError) as e:
-            PlainTextLoader().load(integer)
+            PlainTextLoader().load(integer, None)
 
         assert str(e.value) == f'Unsupported path type "{type(integer)}".'
+
+
+class TestTableLoaders:
+
+    def test_csv_pandas_loader(self, tmp_path, noaa_jfk_schema):
+        "Test the basic functioning of CSVPandasLoader."
+
+        dataset = Dataset(noaa_jfk_schema, tmp_path, mode=Dataset.InitializationMode.DOWNLOAD_AND_LOAD)
+        data = dataset.data['jfk_weather_cleaned']
+        assert isinstance(data, pd.DataFrame)
+        assert len(data) == 75119
+
+    def test_csv_pandas_loader_no_path(self):
+        "Test CSVPandasLoader when fed in with non-path."
+
+        integer = 1
+        with pytest.raises(TypeError) as e:
+            CSVPandasLoader().load(integer, None)
+
+        assert str(e.value) == f'Unsupported path type "{type(integer)}".'
+
+    def test_csv_pandas_loader_non_option(self, tmp_path, noaa_jfk_schema):
+        "Test CSVPandasLoader when None option is passed."
+
+        del noaa_jfk_schema['subdatasets']['jfk_weather_cleaned']['format']['options']
+        dataset = Dataset(noaa_jfk_schema, tmp_path, mode=Dataset.InitializationMode.DOWNLOAD_AND_LOAD)
+        data = dataset.data['jfk_weather_cleaned']
+        assert isinstance(data, pd.DataFrame)
+        assert len(data) == 75119
+
+    def test_csv_pandas_loader_no_encoding(self, tmp_path, noaa_jfk_schema):
+        "Test CSVPandasLoader when no encoding is specified."
+
+        del noaa_jfk_schema['subdatasets']['jfk_weather_cleaned']['format']['options']['encoding']
+        self.test_csv_pandas_loader(tmp_path, noaa_jfk_schema)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -67,10 +67,13 @@ class TestSchema:
         assert loaded_schemata.schemata['dataset_schema'].export_schema()['datasets']['gmb']['1.0.2']['homepage'] == \
             loaded_schemata.schemata['dataset_schema'].export_schema('datasets', 'gmb', '1.0.2', 'homepage')
 
-    def test_schema_without_url(self, loaded_schemata):
+    def test_schema_without_url(self, loaded_schemata, schema_file_http_url):
         "Test instantiating a Schema without supplying a path or url."
 
-        assert DatasetSchema().export_schema() == loaded_schemata.schemata['dataset_schema'].export_schema()
+        class MyDatasetSchema(Schema):
+            DEFAULT_SCHEMA_URL = schema_file_http_url + '/datasets.yaml'
+
+        assert MyDatasetSchema().export_schema() == loaded_schemata.schemata['dataset_schema'].export_schema()
 
     def test_default_schema_url_https(self):
         "Test the default schema URLs are https-schemed."


### PR DESCRIPTION
The first loader that accepts an option, so I also adjusted the way we
accept format a bit.

Because the local `datasets.yaml` file departs from the remote one, this
PR also adjusts some tests.