### PR TITLE
Further reduce CI runtime by having all datasets downloaded only once 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,6 +56,9 @@ branches:
   only:
     - master
 
+cache:
+  - tests/datasets
+
 notifications:
   # For email, only notify the author when the test fails, or succeeds after failing.
   - provider: Email

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ docs/source/api_reference/autosummary/
 
 ### pydax ###
 /pydax/_version.py
+/tests/dataset

--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,4 @@ docs/source/api_reference/autosummary/
 
 ### pydax ###
 /pydax/_version.py
-/tests/dataset
+/tests/datasets

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ branches:
 
 cache:
   directories:
-    - /home/travis/tests/datasets
+    - $HOME/tests/datasets
 
 notifications:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,10 @@ branches:
   only:
     - master
 
+cache:
+  directories:
+    - /home/travis/tests/datasets
+
 notifications:
 
   slack:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,9 +113,18 @@ def schema_file_http_url(local_http_server) -> str:
 
 
 @pytest.fixture
-def downloaded_wikitext103_dataset(wikitext103_schema):
+def downloaded_wikitext103_dataset(wikitext103_schema) -> Dataset:
     with TemporaryDirectory() as tmp_data_dir:
         yield Dataset(wikitext103_schema, data_dir=tmp_data_dir, mode=Dataset.InitializationMode.DOWNLOAD_ONLY)
+
+
+@pytest.fixture
+def downloaded_gmb_dataset(gmb_schema) -> Dataset:
+    with TemporaryDirectory() as tmp_data_dir:
+        yield Dataset(gmb_schema, data_dir=tmp_data_dir, mode=Dataset.InitializationMode.DOWNLOAD_ONLY)
+
+
+# Temporary hacks -------------------------------------
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,17 +14,23 @@
 # limitations under the License.
 #
 
+import copy
+import hashlib
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import threading
+from typing import Callable
+from urllib.request import urlretrieve
 import uuid
 
 import pytest
 
 from pydax import load_schemata
 from pydax.dataset import Dataset
-from pydax.schema import SchemaManager
+from pydax.schema import SchemaDict, SchemaManager
+
+# Basic utilities --------------------------------
 
 
 @pytest.fixture
@@ -52,28 +58,6 @@ def tmp_symlink_dir(tmp_path, tmp_sub_dir):
     symlink_dir.unlink()
 
 
-@pytest.fixture
-def loaded_schemata(schema_file_relative_dir) -> SchemaManager:
-    return load_schemata(dataset_url=schema_file_relative_dir / 'datasets.yaml',
-                         format_url=schema_file_relative_dir / 'formats.yaml',
-                         license_url=schema_file_relative_dir / 'licenses.yaml')
-
-
-@pytest.fixture
-def gmb_schema(loaded_schemata):
-    return loaded_schemata.schemata['dataset_schema'].export_schema('datasets', 'gmb', '1.0.2')
-
-
-@pytest.fixture
-def noaa_jfk_schema(loaded_schemata):
-    return loaded_schemata.schemata['dataset_schema'].export_schema('datasets', 'noaa_jfk', '1.1.4')
-
-
-@pytest.fixture
-def wikitext103_schema(loaded_schemata):
-    return loaded_schemata.schemata['dataset_schema'].export_schema('datasets', 'wikitext103', '1.0.1')
-
-
 @pytest.fixture(scope='session')
 def local_http_server():
     "A local http server that serves the source directory."
@@ -84,32 +68,160 @@ def local_http_server():
         yield httpd
 
 
+@pytest.fixture(scope='session')
+def local_http_server_root_url(local_http_server) -> str:
+    "Root URL of the local http server."
+
+    return f'http://{local_http_server.server_address[0]}:{local_http_server.server_address[1]}'
+
+
+# Dataset --------------------------------------
+
+@pytest.fixture(scope='session')
+def dataset_base_url(local_http_server_root_url) -> str:
+    "The base local HTTP server URL that stores datasets for testing purposes."
+
+    return f'{local_http_server_root_url}/tests/datasets'
+
+
+@pytest.fixture(scope='session')
+def dataset_dir() -> Path:
+    "The directory that stores datasets for testing purposes."
+
+    d = Path('tests/datasets')
+    d.mkdir(exist_ok=True)
+
+    return d
+
+
+@pytest.fixture(scope='session')
+def _download_dataset(dataset_dir, _loaded_schemata) -> Callable[[str], None]:
+    "Utility function for downloading datasets to ``dataset_dir/{name}-{version}`` for testing purpose."
+    # We use _loaded_schemata instead of loaded_schemata to avoid scope mismatch error (a session-scoped fixture can't
+    # call a function-scoped fixture)
+
+    def _download_dataset_impl(name, version):
+        # we drop the 'tar.gz' extension here -- our package should work regardless of the extension, and we allow the
+        # file to be archived in a different compression format.
+        local_destination = dataset_dir / f'{name}-{version}'
+
+        schema = _loaded_schemata.schemata['dataset_schema'].export_schema('datasets', name, version)
+
+        if local_destination.exists() and \
+           hashlib.sha512(local_destination.read_bytes()).hexdigest() == schema['sha512sum']:
+            # The file has been completely downloaded before
+            return
+
+        # We use urllib instead of requests to avoid running the same code path with our downloading implementation
+        urlretrieve(schema['download_url'], filename=local_destination)
+
+    return _download_dataset_impl
+
+# schema fixtures --------------------------------------------------
+
+
+@pytest.fixture(scope='session')
+def _schema(_loaded_schemata, _download_dataset, dataset_base_url) -> Callable[[str, str], SchemaDict]:
+    "Utility function for generating schema fixtures with its downloading URL modified to the local HTTP URL."
+    # We use _loaded_schemata instead of loaded_schemata to avoid scope mismatch error (a session-scoped fixture can't
+    # call a function-scoped fixture)
+
+    def _schema_impl(name, version):
+        _download_dataset(name, version)
+        schema = _loaded_schemata.schemata['dataset_schema'].export_schema('datasets', name, version)
+        schema['download_url'] = str(f'{dataset_base_url}/{name}-{version}')
+        return schema
+
+    return _schema_impl
+
+
+@pytest.fixture(scope='session')
+def _loaded_schemata(schema_file_relative_dir) -> SchemaManager:
+    """Loaded schemata, but this should never be modified. One purpose of this fixture is to reduce repeated call in the
+    test to the same function when ``loaded_schemata`` is used. The other purpose is to provide other session-scoped
+    fixtures access to the loaded schemata, because session-scoped fixtures can't load function-scoped fixtures."""
+
+    return load_schemata(dataset_url=schema_file_relative_dir / 'datasets.yaml',
+                         format_url=schema_file_relative_dir / 'formats.yaml',
+                         license_url=schema_file_relative_dir / 'licenses.yaml')
+
+
 @pytest.fixture
+def loaded_schemata(_loaded_schemata) -> SchemaManager:
+    """A copy of _loaded_schemata. Tests outside this file should always use this one so as to avoid mistakenly
+    modifying the content."""
+
+    return copy.deepcopy(_loaded_schemata)
+
+
+# Every _*_schema fixture also implies that a session wide test dataset file is downloaded. They should only be read
+# because we want them to be session-scoped. All tests should use the fixture without a leading underscore.
+
+# We don't create a function that automatically generates all the following fixtures because explicitly listing them
+# would be easier to understand the error when a test fails.
+
+@pytest.fixture(scope='session')
+def _gmb_schema(_schema):
+    return _schema('gmb', '1.0.2')
+
+
+@pytest.fixture
+def gmb_schema(_gmb_schema):
+    return copy.deepcopy(_gmb_schema)
+
+
+@pytest.fixture(scope='session')
+def _noaa_jfk_schema(_schema):
+    return _schema('noaa_jfk', '1.1.4')
+
+
+@pytest.fixture
+def noaa_jfk_schema(_noaa_jfk_schema):
+    return copy.deepcopy(_noaa_jfk_schema)
+
+
+@pytest.fixture(scope='session')
+def _wikitext103_schema(_schema):
+    return _schema('wikitext103', '1.0.1')
+
+
+@pytest.fixture
+def wikitext103_schema(_wikitext103_schema):
+    return copy.deepcopy(_wikitext103_schema)
+
+
+# schema file locations fixture --------------------------------------
+
+
+@pytest.fixture(scope='session')
 def schema_file_absolute_dir() -> Path:
     "The base of the absolute path to the dir that contains test schema files."
 
     return Path.cwd() / 'tests' / 'schemata'
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def schema_file_relative_dir() -> Path:
     "The base of the relative path to the dir that contains test schema files."
 
     return Path('tests/schemata')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def schema_file_file_url(schema_file_absolute_dir) -> str:
     "The base of file:// schema file URLs."
 
     return schema_file_absolute_dir.as_uri()
 
 
-@pytest.fixture
-def schema_file_http_url(local_http_server) -> str:
+@pytest.fixture(scope='session')
+def schema_file_http_url(local_http_server_root_url) -> str:
     "The base of remote http:// test schema file URLs."
 
-    return f"http://{local_http_server.server_address[0]}:{local_http_server.server_address[1]}/tests/schemata"
+    return f"{local_http_server_root_url}/tests/schemata"
+
+
+# Downloaded datasets -------------------------------------
 
 
 @pytest.fixture

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -64,14 +64,12 @@ class TestDataset:
             Dataset(gmb_schema, data_dir=tmp_path, mode=Dataset.InitializationMode.DOWNLOAD_ONLY)
         assert 'the file may by corrupted' in str(e.value)
 
-    def test_invalid_tarball(self, tmp_path, gmb_schema):
+    def test_invalid_tarball(self, tmp_path, gmb_schema, schema_file_http_url, schema_file_relative_dir):
         "Test if Dataset class catches an invalid tar file."
 
         fake_schema = gmb_schema
-        fake_schema['download_url'] = 'https://dax-cdn.cdn.appdomain.cloud/dax-groningen-meaning-bank-modified/1.0.2/' \
-                                      'data-preview/index.html'
-        fake_schema['sha512sum'] = 'c51be3c51989bb06ef75c7f705843c790bd5a7dd099caf5b31a93cc56e21652e6952d33882eb88902' \
-                                   'b0c0579795126068374764689b4526c2b02130bab694006'
+        fake_schema['download_url'] = schema_file_http_url + '/datasets.yaml'
+        fake_schema['sha512sum'] = hashlib.sha512((schema_file_relative_dir / 'datasets.yaml').read_bytes()).hexdigest()
 
         with pytest.raises(tarfile.ReadError) as e:
             Dataset(fake_schema, data_dir=tmp_path, mode=Dataset.InitializationMode.DOWNLOAD_ONLY)
@@ -155,15 +153,15 @@ class TestDataset:
         dataset = Dataset(gmb_schema, data_dir=tmp_symlink_dir, mode=Dataset.InitializationMode.LAZY)
         assert dataset._data_dir == tmp_symlink_dir
 
-    def test_is_downloaded(self, tmp_path, wikitext103_schema):
+    def test_is_downloaded(self, tmp_path, gmb_schema):
         "Test is_downloaded method."
 
-        data_dir = tmp_path / 'wikitext103' / '1.0.1'
-        wikitext103 = Dataset(wikitext103_schema, data_dir=data_dir, mode=Dataset.InitializationMode.LAZY)
-        assert wikitext103.is_downloaded() is False
+        data_dir = tmp_path / 'gmb' / '1.0.2'
+        gmb = Dataset(gmb_schema, data_dir=data_dir, mode=Dataset.InitializationMode.LAZY)
+        assert gmb.is_downloaded() is False
 
-        wikitext103.download()
-        assert wikitext103.is_downloaded() is True
+        gmb.download()
+        assert gmb.is_downloaded() is True
 
 
 class TestLoadDataset:
@@ -226,22 +224,22 @@ class TestLoadDataset:
         wikitext103_data = load_dataset('wikitext103', version='1.0.1', download=True, subdatasets=subdatasets)
         assert list(wikitext103_data.keys()) == subdatasets
 
-    def test_download_false(self, tmp_path, wikitext103_schema):
+    def test_download_false(self, tmp_path, gmb_schema):
         "Test to see the function loads properly when download=False and dataset was previously downloaded."
 
         init(DATADIR=tmp_path)
-        data_dir = tmp_path / 'wikitext103' / '1.0.1'
-        wikitext103 = Dataset(wikitext103_schema, data_dir=data_dir, mode=Dataset.InitializationMode.DOWNLOAD_AND_LOAD)
-        wikitext103_data = load_dataset('wikitext103', version='1.0.1', download=False)
-        assert wikitext103.data == wikitext103_data
+        data_dir = tmp_path / 'gmb' / '1.0.2'
+        gmb = Dataset(gmb_schema, data_dir=data_dir, mode=Dataset.InitializationMode.DOWNLOAD_AND_LOAD)
+        gmb_data = load_dataset('gmb', version='1.0.2', download=False)
+        assert gmb.data == gmb_data
 
-    def test_download_true(self, tmp_path, downloaded_wikitext103_dataset):
+    def test_download_true(self, tmp_path, downloaded_gmb_dataset):
         "Test to see the function downloads and loads properly when download=True."
 
         init(DATADIR=tmp_path)
-        downloaded_wikitext103_dataset.load()
-        wikitext103_data = load_dataset('wikitext103', version='1.0.1', download=True)
-        assert downloaded_wikitext103_dataset.data == wikitext103_data
+        downloaded_gmb_dataset.load()
+        gmb_data = load_dataset('gmb', version='1.0.2', download=True)
+        assert downloaded_gmb_dataset.data == gmb_data
 
     def test_loading_undownloaded(self, tmp_path):
         "Test loading before ``Dataset.download()`` has been called."


### PR DESCRIPTION
We now download datasets to a local directory, then in most tests,
dataset downloading are from our local HTTP server.

This also helps speed up running tests locally, as downloaded datasets
are saved across test sessions.