### PR TITLE
Add sphinx readthedocs theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,6 +23,8 @@
 import os
 import sys
 
+import sphinx_rtd_theme  # noqa: F401
+
 from pydax import __version__ as pydax_version
 
 # -- Path setup --------------------------------------------------------------
@@ -50,7 +52,8 @@ release = version
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary'
+    'sphinx.ext.autosummary',
+    'sphinx_rtd_theme'
     ]
 
 autosummary_generate = True  # Automate sphinx.ext.autosummary to run when html is generated
@@ -71,7 +74,14 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+html_theme_options = {
+    # TODO: add analytics_id to track traffic in Google Analytics
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
 # Pinning sphinx version recommended by sphinx docs: https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html
 sphinx == 3.3.1
 sphinx-autobuild
+sphinx-rtd-theme

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
     echo Documentation available under {toxworkdir}/docs_out
 
 [pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules --ignore=docs/source/conf.py
 
 [coverage:run]
 source = pydax


### PR DESCRIPTION
Ignore sphinx `conf.py` for `pytest` since it requires a `docs.txt` dependency

![image](https://user-images.githubusercontent.com/54918401/100268952-ccb97880-2f23-11eb-9ddd-dca17c2150b0.png)
