### PR TITLE
In `test_custom_schema`, don't use path separators as URL separators; Explicitly set HTTP server to serve at localhost

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def wikitext103_schema(loaded_schemata):
 def local_http_server():
     "A local http server that serves the source directory."
 
-    with HTTPServer(("", 8080), SimpleHTTPRequestHandler) as httpd:
+    with HTTPServer(("localhost", 8080), SimpleHTTPRequestHandler) as httpd:
         # Start a new thread, because httpd.serve_forever is blocking
         threading.Thread(target=httpd.serve_forever, name='Local Http Server', daemon=True).start()
         yield httpd

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-import os
-
 import pytest
 
 from pydax._schema_retrieval import retrieve_schema_file
@@ -34,7 +32,9 @@ class TestSchemaRetrieval:
 
         # TODO: Add https tests here when we add stronger security measurements
 
-        base = str(request.getfixturevalue('schema_file_' + location_type)) + os.path.sep
+        # We use '/' instead of os.path.sep because URLs only accept / not \ as separators, but Windows path accepts
+        # both. This is not an issue for the purpose of this test.
+        base = str(request.getfixturevalue('schema_file_' + location_type)) + '/'
 
         assert retrieve_schema_file(base + 'datasets.yaml') == \
             (schema_file_relative_dir / 'datasets.yaml').read_text(encoding='utf-8')


### PR DESCRIPTION
This causes errors on Windows, because the URL separators can't be backslash

    tests/test_schema_retrieval.py::TestSchemaRetrieval::test_custom_schema[http_url] PASSED [ 95%]

Also, the default server address 0.0.0.0 seems to be faulty when trying to access it on Windows