### PR TITLE
schema_retrieval should correctly handle Windows-style path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# always check out text files with LF ending. This will maintain consistency for Windows developers and CI.
+* text=auto eol=lf

--- a/pydax/_schema_retrieval.py
+++ b/pydax/_schema_retrieval.py
@@ -40,7 +40,7 @@ def retrieve_schema_file(url_or_path: Union[_typing.PathLike, str], encoding: st
     parse_result = urlparse(url_or_path)
     scheme = parse_result.scheme
 
-    if not all(tuple(parse_result.scheme, parse_result.netloc, parse_result.path)):
+    if not all((parse_result.scheme, parse_result.netloc, parse_result.path)):
         # Not a URL, treated as a local file path
         return Path(url_or_path).read_text(encoding)
     elif scheme in ('http', 'https'):

--- a/pydax/_schema_retrieval.py
+++ b/pydax/_schema_retrieval.py
@@ -38,12 +38,13 @@ def retrieve_schema_file(url_or_path: Union[_typing.PathLike, str], encoding: st
     :return: A string of the content.
     """
 
+    url_or_path = str(url_or_path)
+
     # We don't detect fully whether the input is a URL or a file path because I couldn't find a reliable way. Almost any
     # string with no backslash can be a file name on Linux. URL detection often involves either giant dependencies such
     # as Django, or tediously long regular expression that we can't assure that it would work. Here, we detect the
     # beginning of the string. If it doesn't look like a URL, treat it as a file path.
     if re.match(r'^[a-zA-Z0-9]+:\/\/', url_or_path):
-        url_or_path = str(url_or_path)
         parse_result = urlparse(url_or_path)
         scheme = parse_result.scheme
         if scheme in ('http', 'https'):

--- a/pydax/_schema_retrieval.py
+++ b/pydax/_schema_retrieval.py
@@ -44,7 +44,7 @@ def retrieve_schema_file(url_or_path: Union[_typing.PathLike, str], encoding: st
     # string with no backslash can be a file name on Linux. URL detection often involves either giant dependencies such
     # as Django, or tediously long regular expression that we can't assure that it would work. Here, we detect the
     # beginning of the string. If it doesn't look like a URL, treat it as a file path.
-    if re.match(r'^[a-zA-Z0-9]+:\/\/', url_or_path):
+    if re.match(r'[a-zA-Z0-9]+:\/\/', url_or_path):
         parse_result = urlparse(url_or_path)
         scheme = parse_result.scheme
         if scheme in ('http', 'https'):


### PR DESCRIPTION
Windows-style path "C:\my\path" won't results in an empty scheme.
Instead, we detect first whether the string is a URL or not.

    tests/test_schema_retrieval.py::TestSchemaRetrieval::test_custom_schema[absolute_dir] PASSED [ 89%]