### PR TITLE
Use readthedocs to build/host docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: true
 
 # Set the version of Python and requirements required to build the docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,29 @@
+#
+# Copyright 2020 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# Set the version of Python and requirements required to build the docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements/docs.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,3 +27,5 @@ python:
   version: 3.7
   install:
     - requirements: requirements/docs.txt
+    - method: setuptools
+      path: .


### PR DESCRIPTION
Docs currently built here: https://pydax.readthedocs.io/en/read-the-docs-hosting/index.html
Once PR is merged, will change default branch to be built from `read-the-docs-hosting` to `master` inside of the readthedocs settings