### PR TITLE
Add GitHub actions slack notification

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,14 +45,14 @@ jobs:
         run: tox -e docs -vv
 
       - name: Notify Slack success
-        if: ${{ success() && github.event_name == 'pull_request' }}
+        if: ${{ success() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: good
         uses: rtCamp/action-slack-notify@v2
 
       - name: Notify Slack fail
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: ${{ failure() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,14 +45,14 @@ jobs:
         run: tox -e docs -vv
 
       - name: Notify Slack success
-        if: success()
+        if: ${{ success() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
         color: good
 
       - name: Notify Slack fail
-        if: failure()
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,12 +48,12 @@ jobs:
         if: ${{ success() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+          SLACK_COLOR: good
         uses: rtCamp/action-slack-notify@v2
-        color: good
 
       - name: Notify Slack fail
         if: ${{ failure() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+          SLACK_COLOR: danger
         uses: rtCamp/action-slack-notify@v2
-        color: danger

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,13 +49,13 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: good
-          SLACK_ICON_EMOJI: :drake-yes-:
+          SLACK_ICON_EMOJI: ":drake-yes:"
         uses: rtCamp/action-slack-notify@v2
 
-      - name: Notify Slack fail
+      - name: Notify Slack failure
         if: ${{ failure() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
-          SLACK_ICON_EMOJI: :scott-yikes:
+          SLACK_ICON_EMOJI: ":scott-yikes:"
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,19 +47,11 @@ jobs:
       - name: Notify Slack success
         if: success()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pydax-ci-cd-status
-          status: SUCCESS
-          color: good
+          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+        uses: rtCamp/action-slack-notify@v2
 
       - name: Notify Slack fail
         if: failure()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pydax-ci-cd-status
-          status: FAILED
-          color: danger
+          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+        uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,3 +43,23 @@ jobs:
         run: pip install tox
       - name: Test
         run: tox -e docs -vv
+
+      - name: Notify Slack success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: pydax-ci-cd-status
+          status: SUCCESS
+          color: good
+
+      - name: Notify Slack fail
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: pydax-ci-cd-status
+          status: FAILED
+          color: danger

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,4 +57,5 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
+          SLACK_ICON_EMOJI: :scott-yikes:
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,9 +49,11 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
+        color: good
 
       - name: Notify Slack fail
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
+        color: danger

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: good
+          SLACK_ICON_EMOJI: :drake-yes-:
         uses: rtCamp/action-slack-notify@v2
 
       - name: Notify Slack fail

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,14 +45,14 @@ jobs:
         run: tox -e lint -vv
 
       - name: Notify Slack success
-        if: success()
+        if: ${{ success() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
         color: good
 
       - name: Notify Slack fail
-        if: failure()
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,12 +48,12 @@ jobs:
         if: ${{ success() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+          SLACK_COLOR: good
         uses: rtCamp/action-slack-notify@v2
-        color: good
 
       - name: Notify Slack fail
         if: ${{ failure() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+          SLACK_COLOR: danger
         uses: rtCamp/action-slack-notify@v2
-        color: danger

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,14 +45,14 @@ jobs:
         run: tox -e lint -vv
 
       - name: Notify Slack success
-        if: ${{ success() && github.event_name == 'pull_request' }}
+        if: ${{ success() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: good
         uses: rtCamp/action-slack-notify@v2
 
       - name: Notify Slack fail
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: ${{ failure() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,11 +49,13 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: good
+          SLACK_ICON_EMOJI: ":drake-yes:"
         uses: rtCamp/action-slack-notify@v2
 
-      - name: Notify Slack fail
+      - name: Notify Slack failure
         if: ${{ failure() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
+          SLACK_ICON_EMOJI: ":scott-yikes:"
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,19 +47,11 @@ jobs:
       - name: Notify Slack success
         if: success()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pydax-ci-cd-status
-          status: SUCCESS
-          color: good
+          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+        uses: rtCamp/action-slack-notify@v2
 
       - name: Notify Slack fail
         if: failure()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pydax-ci-cd-status
-          status: FAILED
-          color: danger
+          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+        uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,3 +43,23 @@ jobs:
         run: pip install tox
       - name: Test
         run: tox -e lint -vv
+
+      - name: Notify Slack success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: pydax-ci-cd-status
+          status: SUCCESS
+          color: good
+
+      - name: Notify Slack fail
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: pydax-ci-cd-status
+          status: FAILED
+          color: danger

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,9 +49,11 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
+        color: good
 
       - name: Notify Slack fail
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
+        color: danger

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -83,3 +83,23 @@ jobs:
         run: pip install tox
       - name: Runtime Test
         run: tox -e py -vv
+
+      - name: Notify Slack success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: pydax-ci-cd-status
+          status: SUCCESS
+          color: good
+
+      - name: Notify Slack fail
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: pydax-ci-cd-status
+          status: FAILED
+          color: danger

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -87,19 +87,11 @@ jobs:
       - name: Notify Slack success
         if: success()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pydax-ci-cd-status
-          status: SUCCESS
-          color: good
+          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+        uses: rtCamp/action-slack-notify@v2
 
       - name: Notify Slack fail
         if: failure()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.PYDAX_CICD_SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pydax-ci-cd-status
-          status: FAILED
-          color: danger
+          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+        uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -89,9 +89,11 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
+        color: good
 
       - name: Notify Slack fail
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2
+        color: danger

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -84,8 +84,9 @@ jobs:
       - name: Runtime Test
         run: tox -e py -vv
 
+      # Only notify if a test fails because there are so many runtime tests -- don't spam the channel.
       - name: Notify Slack fail
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: ${{ failure() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -85,9 +85,10 @@ jobs:
         run: tox -e py -vv
 
       # Only notify if a test fails because there are so many runtime tests -- don't spam the channel.
-      - name: Notify Slack fail
+      - name: Notify Slack failure
         if: ${{ failure() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
+          SLACK_ICON_EMOJI: ":scott-yikes:"
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -88,5 +88,5 @@ jobs:
         if: ${{ failure() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
+          SLACK_COLOR: danger
         uses: rtCamp/action-slack-notify@v2
-        color: danger

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -84,15 +84,8 @@ jobs:
       - name: Runtime Test
         run: tox -e py -vv
 
-      - name: Notify Slack success
-        if: success()
-        env:
-          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
-        uses: rtCamp/action-slack-notify@v2
-        color: good
-
       - name: Notify Slack fail
-        if: failure()
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
We only notify the status of the master branch in this channel, so it'll likely stay low-volume and most new info should be of some relevance.
For GitHub Actions, we have notifications for workflows on the master branch:
- For lint and docs, we have notifications whether it's successful or not.
- For runtime, we have notifications only if it failed, because there are just so many of them and we don't have a way to notify only if one of them failed.