### PR TITLE
Solve test_custom_relative_data_dir's failure on Windows

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import os
 import pathlib
 import re
 
@@ -44,11 +43,11 @@ def test_custom_data_dir(tmp_path, wikitext103_schema):
     assert isinstance(wikitext._data_dir, pathlib.Path)
 
 
-def test_custom_relative_data_dir(tmp_path):
+def test_custom_relative_data_dir(chdir_tmp_path, tmp_sub_dir, tmp_relative_sub_dir):
     "Test using a custom relative data directory."
 
-    init(DATADIR=os.path.relpath(tmp_path))
-    assert get_config().DATADIR == tmp_path
+    init(DATADIR=tmp_relative_sub_dir)
+    assert get_config().DATADIR == tmp_sub_dir
     assert get_config().DATADIR.is_absolute()
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -15,7 +15,6 @@
 #
 
 import hashlib
-import os
 import pathlib
 import tarfile
 
@@ -140,14 +139,11 @@ class TestDataset:
             Dataset(gmb_schema, data_dir='./setup.py', mode=Dataset.InitializationMode.DOWNLOAD_ONLY)
         assert str(e.value) == f'"{pathlib.Path.cwd()/"setup.py"}" exists and is not a directory.'
 
-    def test_relative_data_dir(self, gmb_schema):
+    def test_relative_data_dir(self, gmb_schema, chdir_tmp_path, tmp_sub_dir, tmp_relative_sub_dir):
         "Test when ``data_dir`` is relative."
 
-        # We don't use the `tmp_path` fixture here, because if `tmp_path` is on a drive different from the current
-        # working directory on Windows, `os.path.relpath(tmp_path)` would fail.
-        target_path = pathlib.Path.cwd() / 'a' / 'tmp' / 'dir'
-        dataset = Dataset(gmb_schema, data_dir=os.path.relpath(target_path), mode=Dataset.InitializationMode.LAZY)
-        assert dataset._data_dir == target_path
+        dataset = Dataset(gmb_schema, data_dir=tmp_relative_sub_dir, mode=Dataset.InitializationMode.LAZY)
+        assert dataset._data_dir == tmp_sub_dir
         assert dataset._data_dir.is_absolute()
 
     def test_symlink_data_dir(self, tmp_symlink_dir, gmb_schema):


### PR DESCRIPTION
Introduced `tmp_relative_sub_dir` and `chdir_tmp_path` fixtures to
resolve this more cleanly.

```
tests/test_config.py::test_custom_relative_data_dir PASSED [  6%]
```