### PR TITLE
Clean up loaders by not passing None to `options`.

### DIFF
--- a/pydax/loaders/_base.py
+++ b/pydax/loaders/_base.py
@@ -16,7 +16,7 @@
 
 from abc import ABC, abstractmethod
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 from .. import _typing
 from .._schema import SchemaDict
@@ -26,8 +26,8 @@ class Loader(ABC):
     "Base class of all loaders."
 
     @abstractmethod
-    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: Optional[SchemaDict]) -> Any:
-        """Loads from a give path or a dict of path configurations. This should must overridden when inherited.
+    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: SchemaDict) -> Any:
+        """Loads from a give path or a dict of path configurations. This must be overridden when inherited.
 
         :param path: The path or path configurations of the files to be loaded.
         :param options: Options passed to the loader.

--- a/pydax/loaders/_format_loader_map.py
+++ b/pydax/loaders/_format_loader_map.py
@@ -89,11 +89,11 @@ def _load_data_files(fmt: Union[str, SchemaDict], path: Union[str, Dict[str, str
 
     if isinstance(fmt, str):
         fmt_id: str = fmt
-        fmt_options: Optional[SchemaDict] = None
+        fmt_options: SchemaDict = {}
     elif isinstance(fmt, Dict):
         # In Python 3.8, this can be done with isinstance(fmt, typing.get_args(SchemaDict))
         fmt_id = fmt['id']
-        fmt_options = fmt.get('options', None)
+        fmt_options = fmt.get('options', {})
     else:
         raise TypeError(f'Parameter "fmt" must be a string or a dict, but it is of type "{type(fmt)}".')
 

--- a/pydax/loaders/_table.py
+++ b/pydax/loaders/_table.py
@@ -17,7 +17,7 @@
 "Tabular data loaders."
 
 import os
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import pandas as pd  # type: ignore
 
@@ -28,7 +28,7 @@ from ._base import Loader
 
 class CSVPandasLoader(Loader):
 
-    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: Optional[SchemaDict]) -> str:
+    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: SchemaDict) -> str:
         """The type hint says Dict, because this loader will be handling those situations in the future, perhaps via a
         ``IteratingLoader`` class.
 
@@ -42,9 +42,6 @@ class CSVPandasLoader(Loader):
         if not isinstance(path, (str, os.PathLike)):
             # In Python 3.8, this can be done with isinstance(path, typing.get_args(_typing.PathLike))
             raise TypeError(f'Unsupported path type "{type(path)}".')
-
-        if options is None:
-            options = {}
 
         parse_dates = []
         for column, type_ in options.get('columns', {}).items():

--- a/pydax/loaders/_text.py
+++ b/pydax/loaders/_text.py
@@ -1,0 +1,38 @@
+#
+# Copyright 2020 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pathlib
+from typing import Dict, Union
+
+from .. import _typing
+from ..schema import SchemaDict
+from ._base import Loader
+
+
+class PlainTextLoader(Loader):
+
+    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: SchemaDict) -> str:
+        """The type hint says Dict, because this loader will be handling those situations in the future.
+
+        :param path: The path to the plain text file.
+        :param options: Unused.
+        """
+
+        if not isinstance(path, (str, os.PathLike)):
+            # In Python 3.8, this can be done with isinstance(path, typing.get_args(_typing.PathLike))
+            raise TypeError(f'Unsupported path type "{type(path)}".')
+        return pathlib.Path(path).read_text()

--- a/pydax/loaders/text.py
+++ b/pydax/loaders/text.py
@@ -14,25 +14,6 @@
 # limitations under the License.
 #
 
-import os
-import pathlib
-from typing import Dict, Optional, Union
+from ._text import PlainTextLoader
 
-from .. import _typing
-from ..schema import SchemaDict
-from ._base import Loader
-
-
-class PlainTextLoader(Loader):
-
-    def load(self, path: Union[_typing.PathLike, Dict[str, str]], options: Optional[SchemaDict]) -> str:
-        """The type hint says Dict, because this loader will be handling those situations in the future.
-
-        :param path: The path to the plain text file.
-        :param options: Unused.
-        """
-
-        if not isinstance(path, (str, os.PathLike)):
-            # In Python 3.8, this can be done with isinstance(path, typing.get_args(_typing.PathLike))
-            raise TypeError(f'Unsupported path type "{type(path)}".')
-        return pathlib.Path(path).read_text()
+__all__ = ('PlainTextLoader',)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -90,7 +90,7 @@ class TestTextLoaders:
 
         integer = 1
         with pytest.raises(TypeError) as e:
-            PlainTextLoader().load(integer, None)
+            PlainTextLoader().load(integer, {})
 
         assert str(e.value) == f'Unsupported path type "{type(integer)}".'
 
@@ -110,7 +110,7 @@ class TestTableLoaders:
 
         integer = 1
         with pytest.raises(TypeError) as e:
-            CSVPandasLoader().load(integer, None)
+            CSVPandasLoader().load(integer, {})
 
         assert str(e.value) == f'Unsupported path type "{type(integer)}".'
 


### PR DESCRIPTION
This saves implementation of every `Loader.load()` from having

```
if options is None:
    options = {}
```