### PR TITLE
Enhance building the development environment

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-name: Docs
+# Some simple tests to ensure that developers can successfully start the development environment.
+
+name: Development Environment
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -25,12 +27,22 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7]
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.7
+            LC_ALL: C.UTF-8
+          - os: macos-10.15
+            python-version: 3.8
+            LC_ALL: C
+          - os: ubuntu-16.04
+            python-version: 3.9
+            LC_ALL: en.UTF-8
 
-    name: Docs
+
+    name: Python ${{ matrix.python-version }} -- Platform = ${{ matrix.os }} -- LC_ALL = ${{ matrix.LC_ALL }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -41,23 +53,20 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install Dependencies
         run: pip install tox
-      - name: Test
-        run: tox -e docs -vv
+      - name: Build Dev Environment
+        run: tox -e dev -vv
+      - name: Activate dev environment and run a command
+        run: |
+          . .tox/dev/bin/activate
+          pytest -vk test_default_data_dir
+          flake8 setup.py
 
-      - name: Notify Slack success
-        if: ${{ success() && github.event_name == 'push' }}
-        env:
-          SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
-          SLACK_COLOR: good
-          SLACK_ICON_EMOJI: ":drake-yes:"
-          SLACK_TITLE: Message (**Docs**)
-        uses: rtCamp/action-slack-notify@v2
-
+      # Only notify if a test fails because there are 3 tests -- don't spam the channel.
       - name: Notify Slack failure
         if: ${{ failure() && github.event_name == 'push' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
           SLACK_ICON_EMOJI: ":scott-yikes:"
-          SLACK_TITLE: Message (**Docs**)
+          SLACK_TITLE: Message (**Development Environment**)
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,6 +50,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: good
           SLACK_ICON_EMOJI: ":drake-yes:"
+          SLACK_TITLE: Message (**Lint**)
         uses: rtCamp/action-slack-notify@v2
 
       - name: Notify Slack failure
@@ -58,4 +59,5 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
           SLACK_ICON_EMOJI: ":scott-yikes:"
+          SLACK_TITLE: Message (**Lint**)
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -81,4 +81,5 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.PYDAX_CICD_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
           SLACK_ICON_EMOJI: ":scott-yikes:"
+          SLACK_TITLE: Message (**Runtime**)
         uses: rtCamp/action-slack-notify@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,48 +2,78 @@
 
 ## Quick Setup
 
-To start developing, after cloning this repo (and preferably create a virtual environment), run the following command to
-install all dependencies:
+### Use `tox`
 
-    pip install -U -e .
+To start developing, the recommended way is to use `tox`. This way, your development environment is automatically
+prepared by `tox`, including virtual environment setup, dependency management, installing `pydax` in development mode.
+
+1. Install `tox`:
+
+    $ pip install -U tox  # If you are inside a virtual environment, conda environment
+    $ pip3 install --user -U tox  # If you are outside any virtual environment or conda environment
+
+2. At the root directory of `pydax`, run:
+
+    $ tox -e dev
+
+   To force updating development environment in the future, run `tox --recreate -e dev` when the development environment
+   is not activated.
+
+3. To activate the development environment, run:
+
+    $ . .tox/dev/bin/activate
+
+### Traditional Method
+
+Alternatively, after cloning this repository (and preferably having created and activated a virtual environment), run
+the following command to install all dependencies:
+
+    $ pip install -U -e .
 
 Install all required development packages:
 
-    pip install -r requirements-dev.txt
+    $ pip install -U -r requirements-dev.txt
 
-To run all tests on all available Python versions configured to work with PyDAX, run:
+## Run Tests
 
-    tox
+### Run All Tests
 
-By default `tox` uses `virtualenv` for creating each test environment (such as for each Python version). If you would prefer `tox` to use `conda`, run:
+Before and after one stage of development, you may want to try whether the code would pass all tests.
 
-    pip install tox-conda
+To run all tests on the Python versions that are supported by PyDAX and available on your system, run:
 
-## Running Tests Individually
+    $ tox -s
 
-To test the functioning of the package, run:
+When you are brave, to force running all tests on all Python versions that are supported by PyDAX, run:
 
-    coverage run -m pytest
+    $ tox
 
-To understand the coverage of the test above, run:
+By default `tox` uses `virtualenv` for creating each test environment (such as for each Python version). If you would
+prefer `tox` to use `conda`, run:
 
-    coverage report
+    $ pip install tox-conda
 
-To check Python code style compliance, run:
+### Running Part of the Tests
 
-    flake8 .
+During development, you likely would like to run only part of the tests to save time.
 
-To check YAML code style compliance, run:
+To run all static tests, run:
 
-    yamllint -c .yamllint.yaml .
+    $ tox -e lint
 
-For static security check, run:
+To run all runtime tests on the Python version in the development environment, run:
 
-    bandit -r .
+    $ tox -e py
 
-For type annotation test, run:
+To run only a specific runtime test, run:
 
-    mypy pydax
+    $ pytest -vk [test_name]  # e.g., pytest -vk test_default_data_dir
+
+Read [pytest command line document](https://docs.pytest.org/en/stable/usage.html) for its more advanced usage.
+
+To run document generation tests, run:
+
+    $ tox -e docs
 
 ## Where to Expose a Symbol (Function, Class, etc.)?
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+tox
 -r requirements/lint.txt
 -r requirements/test.txt
 -r requirements/docs.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -8,5 +8,4 @@ mccabe
 # Fix mypy to a previous version for now due to a regression: https://github.com/python/typeshed/issues/4681
 mypy == 0.782
 rstcheck
-tox
 yamllint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
 # Dependencies for runtime test
 coverage
 pytest
-tox

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,12 @@ commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" -b html -W --color
     echo Documentation available under {toxworkdir}/docs_out
 
+[testenv:dev]
+usedevelop = True
+description = Development environment
+deps = -rrequirements-dev.txt
+commands = {envpython} -c "print(r'{envpython}')"
+
 [pytest]
 addopts = --doctest-modules --ignore=docs/source/conf.py
 


### PR DESCRIPTION
Also added one more simple CI test to have some degree of guarantee
that developers can successfully build the development environment by
following the instructions.

This is partly borrowed from tox's own practice: https://github.com/tox-dev/tox/blob/11b98d71a9ba801d6f8a6cd199739bb58a63f12c/tox.ini#L177 and their examples: https://tox.readthedocs.io/en/latest/example/devenv.html#example-1-basic-scenario