### PR TITLE
Allow customization of default schema file URLs

### DIFF
--- a/docs/source/api_reference/pydax.schema.rst
+++ b/docs/source/api_reference/pydax.schema.rst
@@ -32,7 +32,6 @@ DatasetSchema Class
 
    DatasetSchema
    DatasetSchema.export_schema
-   DatasetSchema.DEFAULT_SCHEMA_URL
 
 
 
@@ -44,7 +43,6 @@ FormatSchema Class
 
    FormatSchema
    FormatSchema.export_schema
-   FormatSchema.DEFAULT_SCHEMA_URL
 
 
 LicenseSchema Class
@@ -55,4 +53,3 @@ LicenseSchema Class
 
    LicenseSchema
    LicenseSchema.export_schema
-   LicenseSchema.DEFAULT_SCHEMA_URL

--- a/pydax/_schema.py
+++ b/pydax/_schema.py
@@ -19,10 +19,11 @@
 
 from abc import ABC
 from copy import deepcopy
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional
 
 import yaml
 
+from ._config import get_config
 from ._schema_retrieval import retrieve_schema_file
 
 
@@ -33,19 +34,11 @@ class Schema(ABC):
     """Abstract class that provides functionality to load and export schemata.
 
     :param url_or_path: URL or path to a schema file.
-    :raise AttributeError: DEFAULT_SCHEMA_URL is not overridden.
     """
 
-    def __init__(self, url_or_path: Union[str, None] = None) -> None:
+    def __init__(self, url_or_path: str) -> None:
         """Constructor method.
         """
-        if url_or_path is None:
-            try:
-                url_or_path = self.__class__.DEFAULT_SCHEMA_URL  # type: ignore [attr-defined]
-            except AttributeError as e:
-                raise AttributeError("DEFAULT_SCHEMA_URL is not defined. "
-                                     'Have you forgotten to define this variable when inheriting "Schema"?\n'
-                                     f"Caused by:\n{e}")
         self._schema: SchemaDict = self._load_retrieved_schema(retrieve_schema_file(url_or_path))
 
     def _load_retrieved_schema(self, schema: str) -> SchemaDict:
@@ -70,29 +63,26 @@ class Schema(ABC):
 
 class DatasetSchema(Schema):
     """Dataset schema class that inherits functionality from :class:`Schema`.
-
-    :param url_or_path: URL or path to a schema file
     """
 
-    DEFAULT_SCHEMA_URL = 'https://ibm.box.com/shared/static/01oa3ue32lzcsd2znlbojs9ozdeftpb6.yaml'
+    # We have this class here because we reserve the potential to put specific dataset schema code here
+    pass
 
 
 class FormatSchema(Schema):
     """Format schema class that inherits functionality from :class:`Schema`.
-
-    :param url_or_path: URL or path to a schema file
     """
 
-    DEFAULT_SCHEMA_URL = 'https://ibm.box.com/shared/static/sv9hyf9vjdiareodbgo6kz5o8prxfm51.yaml'
+    # We have this class here because we reserve the potential to put specific format schema code here
+    pass
 
 
 class LicenseSchema(Schema):
     """License schema class that inherits functionality from :class:`Schema`.
-
-    :param url_or_path: URL or path to a schema file
     """
 
-    DEFAULT_SCHEMA_URL = ('https://ibm.box.com/shared/static/iy5xq7vk53dss5pgs0xvrfol9tfyd7ya.yaml')
+    # We have this class here because we reserve the potential to put specific license schema code here
+    pass
 
 
 class SchemaManager():
@@ -120,9 +110,9 @@ class SchemaManager():
 
 
 def load_schemata(*,
-                  dataset_url: str = DatasetSchema.DEFAULT_SCHEMA_URL,
-                  format_url: str = FormatSchema.DEFAULT_SCHEMA_URL,
-                  license_url: str = LicenseSchema.DEFAULT_SCHEMA_URL) -> SchemaManager:
+                  dataset_url: Optional[str] = None,
+                  format_url: Optional[str] = None,
+                  license_url: Optional[str] = None) -> SchemaManager:
     """Helper function to load and provide all schemata.
 
     :param dataset_url: Dataset schema url, defaults to DatasetSchema.DEFAULT_SCHEMA_DATASETS_URL
@@ -130,6 +120,13 @@ def load_schemata(*,
     :param license_url: License schema url, defaults to LicenseSchema.DEFAULT_SCHEMA_LICENSES_URL
     :return: A :class:`SchemaManager` object which holds the loaded schemata in :attr:`schemata`
     """
+    if dataset_url is None:
+        dataset_url = get_config().DEFAULT_DATASET_SCHEMA_URL
+    if format_url is None:
+        format_url = get_config().DEFAULT_FORMAT_SCHEMA_URL
+    if license_url is None:
+        license_url = get_config().DEFAULT_LICENSE_SCHEMA_URL
+
     return SchemaManager(dataset_schema=DatasetSchema(dataset_url),
                          format_schema=FormatSchema(format_url),
                          license_schema=LicenseSchema(license_url))

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     data_files=[("", ["LICENSE"])],
     python_requires=">=3.6",
     install_requires=[
+        "dataclasses; python_version < '3.7.0'",  # backported dataclasses
         "packaging >= 20.4",
         "pandas >= 1.1.0",
         "pydantic >= 1.7.2",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,7 +112,7 @@ def test_default_schema_url_content():
     # more regularly than the library. For this reason, we also verify the default schema URLs are also valid https
     # links in ``test_default_schema_url_https``.
 
-    # This test is in `test_schema.py` not in `test_schema_retrieval.py` because this test is more about the content
+    # This test is in `test_config.py` not in `test_schema_retrieval.py` because this test is more about the content
     # of the default schema URLs than the retrieving functionality.
     assert len(retrieve_schema_file(Config.DEFAULT_DATASET_SCHEMA_URL)) > 0
     assert len(retrieve_schema_file(Config.DEFAULT_FORMAT_SCHEMA_URL)) > 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,14 +14,19 @@
 # limitations under the License.
 #
 
+import dataclasses
 import pathlib
 import re
+from urllib.parse import urlparse
 
 import pytest
 from pydantic import ValidationError
+import requests.exceptions
 
 from pydax import get_config, init
+from pydax._config import Config
 from pydax.dataset import Dataset
+from pydax._schema_retrieval import retrieve_schema_file
 
 
 def test_default_data_dir(wikitext103_schema):
@@ -66,3 +71,49 @@ def test_non_path_data_dir():
 
     assert re.search(r"1 validation error for Config\s+DATADIR\s+value is not a valid path \(type=type_error.path\)",
                      str(e.value))
+
+
+def test_custom_configs():
+    "Test custom configs."
+
+    init(update_only=False)  # set back everything to default
+    assert dataclasses.asdict(get_config()) == dataclasses.asdict(Config())
+
+    new_urls = {
+        'DEFAULT_DATASET_SCHEMA_URL': 'some/local/file',
+        'DEFAULT_FORMAT_SCHEMA_URL': 'file://c:/some/other/local/file',
+        'DEFAULT_LICENSE_SCHEMA_URL': 'http://some/remote/file'
+    }
+    init(update_only=True, **new_urls)
+
+    for url, val in new_urls.items():
+        assert getattr(get_config(), url) == val
+    assert get_config().DATADIR == Config.DATADIR
+
+
+def test_default_schema_url_https():
+    "Test the default schema URLs are https-schemed."
+
+    assert urlparse(Config.DEFAULT_DATASET_SCHEMA_URL).scheme == 'https'
+    assert urlparse(Config.DEFAULT_FORMAT_SCHEMA_URL).scheme == 'https'
+    assert urlparse(Config.DEFAULT_LICENSE_SCHEMA_URL).scheme == 'https'
+
+
+@pytest.mark.xfail(reason="default remote might be down but it's not this library's issue",
+                   raises=requests.exceptions.ConnectionError)
+def test_default_schema_url_content():
+    """Test the content of the remote URLs a bit. We only assert them not being None here just in case the server
+    returns zero-length files."""
+
+    init(update_only=False)
+
+    # We only assert that we have retrieved some non-empty files in this test. This is because we want to decouple
+    # the maintenance of schema files in production with the library development. These files likely would change
+    # more regularly than the library. For this reason, we also verify the default schema URLs are also valid https
+    # links in ``test_default_schema_url_https``.
+
+    # This test is in `test_schema.py` not in `test_schema_retrieval.py` because this test is more about the content
+    # of the default schema URLs than the retrieving functionality.
+    assert len(retrieve_schema_file(Config.DEFAULT_DATASET_SCHEMA_URL)) > 0
+    assert len(retrieve_schema_file(Config.DEFAULT_FORMAT_SCHEMA_URL)) > 0
+    assert len(retrieve_schema_file(Config.DEFAULT_LICENSE_SCHEMA_URL)) > 0

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -25,7 +25,7 @@ from pydax import init, list_all_datasets, load_dataset
 from pydax.dataset import Dataset
 
 
-def test_list_all_datasets(spoofed_default_url):
+def test_list_all_datasets():
     "Test to make sure test_list_all_datasets function returns available dataset names."
 
     datasets = list_all_datasets()


### PR DESCRIPTION
I moved the default settings to _config.py, because these URLs are only
used by our convenient wrappers and not by our advanced features.