### PR TITLE
Cache loaded schemata in memory

### DIFF
--- a/docs/source/api_reference/pydax.rst
+++ b/docs/source/api_reference/pydax.rst
@@ -10,9 +10,10 @@ Functions
 .. autosummary::
    :toctree: autosummary
 
-   init
+   export_schemata
    get_config
    get_dataset_metadata
+   init
    list_all_datasets
    load_dataset
    load_schemata

--- a/pydax/__init__.py
+++ b/pydax/__init__.py
@@ -20,7 +20,7 @@
 from . import dataset, loaders, schema
 from ._config import get_config, init
 from ._dataset import get_dataset_metadata, list_all_datasets, load_dataset
-from ._schema import load_schemata
+from ._schema import export_schemata, load_schemata
 from ._version import version as __version__
 
 __all__ = (
@@ -36,6 +36,7 @@ __all__ = (
            'list_all_datasets',
            'load_dataset',
            # _schema
+           'export_schemata',
            'load_schemata',
            # _version
            '__version__'

--- a/pydax/_dataset.py
+++ b/pydax/_dataset.py
@@ -32,7 +32,7 @@ import requests
 
 from . import _typing
 from ._config import get_config
-from ._schema import load_schemata
+from ._schema import get_schemata
 from .schema import SchemaDict
 from .loaders._format_loader_map import _load_data_files
 
@@ -43,7 +43,7 @@ def list_all_datasets() -> Dict[str, Tuple]:
     :return: Mapping of available datasets and their versions
     """
 
-    dataset_schema = load_schemata().schemata['dataset_schema'].export_schema('datasets')
+    dataset_schema = get_schemata().schemata['datasets'].export_schema('datasets')
     return {
         outer_k: tuple(inner_k for inner_k, inner_v in outer_v.items())
         for outer_k, outer_v in dataset_schema.items()
@@ -302,7 +302,7 @@ def load_dataset(name: str, *,
     :return: Dictionary that holds all subdatasets.
     """
 
-    schema = load_schemata().schemata['dataset_schema'].export_schema('datasets', name, version)
+    schema = get_schemata().schemata['datasets'].export_schema('datasets', name, version)
 
     data_dir = get_config().DATADIR / name / version
     dataset = Dataset(schema=schema, data_dir=data_dir, mode=Dataset.InitializationMode.LAZY)
@@ -334,9 +334,9 @@ def get_dataset_metadata(name: str, *,
     :return: Return a dataset's metadata either as a string or as a schema dictionary.
     """
 
-    schema_manager = load_schemata()
-    dataset_schema = schema_manager.schemata['dataset_schema'].export_schema('datasets', name, version)
-    license_schema = schema_manager.schemata['license_schema'].export_schema('licenses')
+    schema_manager = get_schemata()
+    dataset_schema = schema_manager.schemata['datasets'].export_schema('datasets', name, version)
+    license_schema = schema_manager.schemata['licenses'].export_schema('licenses')
     if human:
         return (f'Dataset name: {dataset_schema["name"]}\n'
                 f'Description: {dataset_schema["description"]}\n'

--- a/pydax/_dataset.py
+++ b/pydax/_dataset.py
@@ -32,7 +32,7 @@ import requests
 
 from . import _typing
 from ._config import get_config
-from ._schema import get_schemata
+from ._schema import export_schemata
 from .schema import SchemaDict
 from .loaders._format_loader_map import _load_data_files
 
@@ -43,7 +43,7 @@ def list_all_datasets() -> Dict[str, Tuple]:
     :return: Mapping of available datasets and their versions
     """
 
-    dataset_schema = get_schemata().schemata['datasets'].export_schema('datasets')
+    dataset_schema = export_schemata().schemata['datasets'].export_schema('datasets')
     return {
         outer_k: tuple(inner_k for inner_k, inner_v in outer_v.items())
         for outer_k, outer_v in dataset_schema.items()
@@ -302,7 +302,7 @@ def load_dataset(name: str, *,
     :return: Dictionary that holds all subdatasets.
     """
 
-    schema = get_schemata().schemata['datasets'].export_schema('datasets', name, version)
+    schema = export_schemata().schemata['datasets'].export_schema('datasets', name, version)
 
     data_dir = get_config().DATADIR / name / version
     dataset = Dataset(schema=schema, data_dir=data_dir, mode=Dataset.InitializationMode.LAZY)
@@ -334,7 +334,7 @@ def get_dataset_metadata(name: str, *,
     :return: Return a dataset's metadata either as a string or as a schema dictionary.
     """
 
-    schema_manager = get_schemata()
+    schema_manager = export_schemata()
     dataset_schema = schema_manager.schemata['datasets'].export_schema('datasets', name, version)
     license_schema = schema_manager.schemata['licenses'].export_schema('licenses')
     if human:

--- a/pydax/_schema.py
+++ b/pydax/_schema.py
@@ -148,7 +148,8 @@ def load_schemata(*, force_reload: bool = False) -> None:
 def get_schemata() -> SchemaManager:
     """Return the :class:`SchemaManager` object managed by high-level functions. If it is not created, create it. This
     function is used by high-level APIs but it should not be a high-level function itself. It should only be used
-    internally because users should not have this easy access to modify the managed :class`SchemaManager` object."""
+    internally when the need to modify the managed :class`SchemaManager` object arises. It should not be exposed for the
+    same reason: users should not have this easy access to modify the managed :class`SchemaManager` object."""
 
     global _schemata
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,9 @@ import uuid
 
 import pytest
 
-from pydax import init, load_schemata
+from pydax import init
 from pydax.dataset import Dataset
-from pydax.schema import SchemaDict, SchemaManager
+from pydax.schema import Schema, SchemaDict, SchemaManager
 
 # Basic utilities --------------------------------
 
@@ -103,9 +103,9 @@ def pydax_initialization(schema_file_http_url):
     (default schema files and this library)."""
 
     init(update_only=False,
-         DEFAULT_DATASET_SCHEMA_URL=f'{schema_file_http_url}/datasets.yaml',
-         DEFAULT_FORMAT_SCHEMA_URL=f'{schema_file_http_url}/formats.yaml',
-         DEFAULT_LICENSE_SCHEMA_URL=f'{schema_file_http_url}/licenses.yaml')
+         DATASET_SCHEMA_URL=f'{schema_file_http_url}/datasets.yaml',
+         FORMAT_SCHEMA_URL=f'{schema_file_http_url}/formats.yaml',
+         LICENSE_SCHEMA_URL=f'{schema_file_http_url}/licenses.yaml')
 
 # Dataset --------------------------------------
 
@@ -138,7 +138,7 @@ def _download_dataset(dataset_dir, _loaded_schemata) -> Callable[[str], None]:
         # file to be archived in a different compression format.
         local_destination = dataset_dir / f'{name}-{version}'
 
-        schema = _loaded_schemata.schemata['dataset_schema'].export_schema('datasets', name, version)
+        schema = _loaded_schemata.schemata['datasets'].export_schema('datasets', name, version)
 
         if local_destination.exists() and \
            hashlib.sha512(local_destination.read_bytes()).hexdigest() == schema['sha512sum']:
@@ -161,7 +161,7 @@ def _schema(_loaded_schemata, _download_dataset, dataset_base_url) -> Callable[[
 
     def _schema_impl(name, version):
         _download_dataset(name, version)
-        schema = _loaded_schemata.schemata['dataset_schema'].export_schema('datasets', name, version)
+        schema = _loaded_schemata.schemata['datasets'].export_schema('datasets', name, version)
         schema['download_url'] = str(f'{dataset_base_url}/{name}-{version}')
         return schema
 
@@ -174,9 +174,9 @@ def _loaded_schemata(schema_file_relative_dir) -> SchemaManager:
     test to the same function when ``loaded_schemata`` is used. The other purpose is to provide other session-scoped
     fixtures access to the loaded schemata, because session-scoped fixtures can't load function-scoped fixtures."""
 
-    return load_schemata(dataset_url=schema_file_relative_dir / 'datasets.yaml',
-                         format_url=schema_file_relative_dir / 'formats.yaml',
-                         license_url=schema_file_relative_dir / 'licenses.yaml')
+    return SchemaManager(datasets=Schema(schema_file_relative_dir / 'datasets.yaml'),
+                         formats=Schema(schema_file_relative_dir / 'formats.yaml'),
+                         licenses=Schema(schema_file_relative_dir / 'licenses.yaml'))
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,9 +80,9 @@ def test_custom_configs():
     assert dataclasses.asdict(get_config()) == dataclasses.asdict(Config())
 
     new_urls = {
-        'DEFAULT_DATASET_SCHEMA_URL': 'some/local/file',
-        'DEFAULT_FORMAT_SCHEMA_URL': 'file://c:/some/other/local/file',
-        'DEFAULT_LICENSE_SCHEMA_URL': 'http://some/remote/file'
+        'DATASET_SCHEMA_URL': 'some/local/file',
+        'FORMAT_SCHEMA_URL': 'file://c:/some/other/local/file',
+        'LICENSE_SCHEMA_URL': 'http://some/remote/file'
     }
     init(update_only=True, **new_urls)
 
@@ -94,9 +94,9 @@ def test_custom_configs():
 def test_default_schema_url_https():
     "Test the default schema URLs are https-schemed."
 
-    assert urlparse(Config.DEFAULT_DATASET_SCHEMA_URL).scheme == 'https'
-    assert urlparse(Config.DEFAULT_FORMAT_SCHEMA_URL).scheme == 'https'
-    assert urlparse(Config.DEFAULT_LICENSE_SCHEMA_URL).scheme == 'https'
+    assert urlparse(Config.DATASET_SCHEMA_URL).scheme == 'https'
+    assert urlparse(Config.FORMAT_SCHEMA_URL).scheme == 'https'
+    assert urlparse(Config.LICENSE_SCHEMA_URL).scheme == 'https'
 
 
 @pytest.mark.xfail(reason="default remote might be down but it's not this library's issue",
@@ -114,6 +114,6 @@ def test_default_schema_url_content():
 
     # This test is in `test_config.py` not in `test_schema_retrieval.py` because this test is more about the content
     # of the default schema URLs than the retrieving functionality.
-    assert len(retrieve_schema_file(Config.DEFAULT_DATASET_SCHEMA_URL)) > 0
-    assert len(retrieve_schema_file(Config.DEFAULT_FORMAT_SCHEMA_URL)) > 0
-    assert len(retrieve_schema_file(Config.DEFAULT_LICENSE_SCHEMA_URL)) > 0
+    assert len(retrieve_schema_file(Config.DATASET_SCHEMA_URL)) > 0
+    assert len(retrieve_schema_file(Config.FORMAT_SCHEMA_URL)) > 0
+    assert len(retrieve_schema_file(Config.LICENSE_SCHEMA_URL)) > 0

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -296,8 +296,8 @@ class TestGetDatasetMetadata:
         name, version = 'gmb', '1.0.2'
 
         gmb_metadata = get_dataset_metadata(name, version=version)
-        dataset_schema = loaded_schemata.schemata['dataset_schema'].export_schema('datasets', name, version)
-        license_schema = loaded_schemata.schemata['license_schema'].export_schema('licenses')
+        dataset_schema = loaded_schemata.schemata['datasets'].export_schema('datasets', name, version)
+        license_schema = loaded_schemata.schemata['licenses'].export_schema('licenses')
         assert gmb_metadata == (f'Dataset name: {dataset_schema["name"]}\n'
                                 f'Description: {dataset_schema["description"]}\n'
                                 f'Size: {dataset_schema["estimated_size"]}\n'
@@ -306,4 +306,4 @@ class TestGetDatasetMetadata:
                                 f'Available subdatasets: {", ".join(dataset_schema["subdatasets"].keys())}')
 
         gmb_schema = get_dataset_metadata(name, version=version, human=False)
-        assert gmb_schema == loaded_schemata.schemata['dataset_schema'].export_schema('datasets', name, version)
+        assert gmb_schema == loaded_schemata.schemata['datasets'].export_schema('datasets', name, version)


### PR DESCRIPTION
Made some structural changes regarding the high-level schema loading
part.

- `load_schemata` shouldn't return a SchemaManager object as the user
  should not be allowed to tweak an object that is managed by high-level
  APIs.
- Added `export_schemata` for users who want to peek in what the
  schemata look like.
- Rename `Config.DEFAULT_*` to `Config.*` because they are the
  configuration for high-level APIs, not defaults. The defaults are
  what's at the right side of the equal sign.
- Added `retrieved_url_or_path` to `Schema` as it is useful as a Schema
  member and is useful for this PR.
- Removed the `_schema` suffix in `SchemaManager.schemata`'s keys:
  `dataset_schema`, `license_schema`, `format_schema`. What other than
  `Schema` could be stored in `SchemaManager.schemata`?

I left some less core parts as TODO to avoid making this PR smaller.

---

I should have broken this PR into smaller pieces (like the renaming part), but it was too late when I regret. Hope this is not (yet) too disastrous for review.