### PR TITLE
Dependabot should only label its PRs "dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependabot"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependabot"


### PR DESCRIPTION
By default it also adds a "Python" or "GitHub Actions" tag, which doesn't give much useful information.