### PR TITLE
Add an option to retrieve schema files securely/insecurely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ docs/source/api_reference/autosummary/
 ### pydax ###
 /pydax/_version.py
 /tests/datasets
+/tests/tls/test_ca_bundle.pem

--- a/pydax/__init__.py
+++ b/pydax/__init__.py
@@ -17,7 +17,7 @@
 "PyDAX package"
 
 
-from . import dataset, loaders, schema
+from . import dataset, exceptions, loaders, schema
 from ._high_level import (export_schemata,
                           get_config,
                           get_dataset_metadata,
@@ -30,6 +30,7 @@ from ._version import version as __version__
 __all__ = (
            # modules & subpackages
            'dataset',
+           'exceptions',
            'loaders',
            'schema',
            # high-level functions

--- a/pydax/exceptions.py
+++ b/pydax/exceptions.py
@@ -1,0 +1,22 @@
+#
+# Copyright 2020 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"Exceptions of this module."
+
+
+class InsecureConnectionError(RuntimeError):
+    "The connection is insecure."
+    pass

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -61,11 +61,11 @@ class TestDataset:
             Dataset(gmb_schema, data_dir=tmp_path, mode=Dataset.InitializationMode.DOWNLOAD_ONLY)
         assert 'the file may by corrupted' in str(e.value)
 
-    def test_invalid_tarball(self, tmp_path, gmb_schema, schema_file_http_url, schema_file_relative_dir):
+    def test_invalid_tarball(self, tmp_path, gmb_schema, schema_file_https_url, schema_file_relative_dir):
         "Test if Dataset class catches an invalid tar file."
 
         fake_schema = gmb_schema
-        fake_schema['download_url'] = schema_file_http_url + '/datasets.yaml'
+        fake_schema['download_url'] = schema_file_https_url + '/datasets.yaml'
         fake_schema['sha512sum'] = hashlib.sha512((schema_file_relative_dir / 'datasets.yaml').read_bytes()).hexdigest()
 
         with pytest.raises(tarfile.ReadError) as e:

--- a/tests/test_high_level.py
+++ b/tests/test_high_level.py
@@ -239,7 +239,7 @@ class TestSchemataFunctions:
                     loaded_schemata.schemata[name].retrieved_url_or_path)
         assert _get_schemata().schemata['datasets'].retrieved_url_or_path == schema_file_absolute_dir / 'datasets.yaml'
 
-    def test_export_schemata(self, schema_file_absolute_dir, schema_file_http_url):
+    def test_export_schemata(self, schema_file_absolute_dir, schema_file_https_url):
         "Test high-level export-schemata function."
 
         assert export_schemata() is not _get_schemata()
@@ -248,12 +248,12 @@ class TestSchemataFunctions:
                            sort_keys=True, indent=2, default=str) ==
                 json.dumps(_get_schemata().schemata['datasets'].export_schema(), sort_keys=True, indent=2, default=str))
 
-        # Different from http url used by pydax_initialization autouse fixture
+        # Different from https url used by pydax_initialization autouse fixture
         new_urls = {
             'DATASET_SCHEMA_URL': schema_file_absolute_dir / 'datasets.yaml',
             'LICENSE_SCHEMA_URL': schema_file_absolute_dir / 'licenses.yaml'
         }
         init(update_only=True, **new_urls)
-        assert export_schemata().schemata['formats'].retrieved_url_or_path == f'{schema_file_http_url}/formats.yaml'
+        assert export_schemata().schemata['formats'].retrieved_url_or_path == f'{schema_file_https_url}/formats.yaml'
         assert export_schemata().schemata['datasets'].retrieved_url_or_path == new_urls['DATASET_SCHEMA_URL']
         assert export_schemata().schemata['licenses'].retrieved_url_or_path == new_urls['LICENSE_SCHEMA_URL']

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -25,7 +25,7 @@ class TestSchemaRetrieval:
 
     # We set tls_verification to False in this test. We don't test raising this warning because it is not within the
     # project's scope to guarantee that this warning will raise, and this warning raises only once, which means that
-    # whether the warning will be raised depending on the order in which the tests being executed.
+    # whether the warning will be raised depends on the order in which the tests are being executed.
     @pytest.mark.filterwarnings('ignore:Unverified HTTPS request .*:urllib3.exceptions.InsecureRequestWarning')
     @pytest.mark.parametrize('location_type',
                              ('absolute_dir',

--- a/tests/test_schema_retrieval.py
+++ b/tests/test_schema_retrieval.py
@@ -16,40 +16,45 @@
 
 import pytest
 
+from pydax.exceptions import InsecureConnectionError
 from pydax._schema_retrieval import retrieve_schema_file
 
 
 class TestSchemaRetrieval:
     "Test schema retrieval."
 
+    # We set tls_verification to False in this test. We don't test raising this warning because it is not within the
+    # project's scope to guarantee that this warning will raise, and this warning raises only once, which means that
+    # whether the warning will be raised depending on the order in which the tests being executed.
+    @pytest.mark.filterwarnings('ignore:Unverified HTTPS request .*:urllib3.exceptions.InsecureRequestWarning')
     @pytest.mark.parametrize('location_type',
                              ('absolute_dir',
                               'relative_dir',
                               'file_url',
                               'http_url',
                               'https_url'))
-    def test_custom_schema(self, location_type, schema_file_relative_dir, request):
-        "Test retrieving user-specified schema files."
+    def test_custom_schema_insecure(self, location_type, schema_file_relative_dir, request):
+        "Test retrieving user-specified schema files, with insecure connections allowed."
 
         # We use '/' instead of os.path.sep because URLs only accept / not \ as separators, but Windows path accepts
         # both. This is not an issue for the purpose of this test.
         base = str(request.getfixturevalue('schema_file_' + location_type)) + '/'
 
-        assert retrieve_schema_file(base + 'datasets.yaml') == \
+        assert retrieve_schema_file(base + 'datasets.yaml', tls_verification=False) == \
             (schema_file_relative_dir / 'datasets.yaml').read_text(encoding='utf-8')
-        assert retrieve_schema_file(base + 'formats.yaml', encoding='ascii') == \
+        assert retrieve_schema_file(base + 'formats.yaml', encoding='ascii', tls_verification=False) == \
             (schema_file_relative_dir / 'formats.yaml').read_text(encoding='ascii')
         with pytest.raises(UnicodeDecodeError) as e:
-            retrieve_schema_file(base + 'licenses.yaml', encoding='ascii')
+            retrieve_schema_file(base + 'licenses.yaml', encoding='ascii', tls_verification=False)
         # We usually don't assert the position info because we don't want to rewrite this test every time the yaml
         # file changes in length.
         assert "'ascii' codec can't decode byte 0xe2" in str(e.value)
         with pytest.raises(UnicodeDecodeError) as e:
-            retrieve_schema_file(base + 'formats-utf-16le-bom.yaml')
+            retrieve_schema_file(base + 'formats-utf-16le-bom.yaml', tls_verification=False)
         # Test "position 0" here because it should fail at the beginning of the decoding
         assert "'utf-8' codec can't decode byte 0xff in position 0" in str(e.value)
         with pytest.raises(UnicodeDecodeError) as e:
-            retrieve_schema_file(base + 'formats-utf-16be.yaml', encoding='utf-8')
+            retrieve_schema_file(base + 'formats-utf-16be.yaml', encoding='utf-8', tls_verification=False)
         assert "'utf-8' codec can't decode byte 0x90" in str(e.value)
 
     def test_invalid_schema(self):
@@ -59,3 +64,25 @@ class TestSchemaRetrieval:
             retrieve_schema_file(url_or_path='ftp://ftp/is/unsupported')
 
         assert str(e.value) == 'Unknown scheme in "ftp://ftp/is/unsupported": "ftp"'
+
+    @pytest.mark.parametrize('location_type', ('http_url', 'https_url'))
+    def test_insecure_connections_fail(self, location_type, untrust_self_signed_cert, request):
+        "Test insecure connections that should fail."
+        url = str(request.getfixturevalue('schema_file_' + location_type)) + '/datasets.yaml'
+        with pytest.raises(InsecureConnectionError) as e:
+            retrieve_schema_file(url, tls_verification=True)
+        assert url in str(e.value)
+        assert retrieve_schema_file.__kwdefaults__['tls_verification'] is True
+
+    @pytest.mark.parametrize('location_type',
+                             ('absolute_dir',
+                              'relative_dir',
+                              'file_url',
+                              'https_url'))
+    def test_insecure_connections_succeed(self, location_type, schema_file_relative_dir, request):
+        "Test secure connections that should succeed."
+        # We use '/' instead of os.path.sep because URLs only accept / not \ as separators, but Windows path accepts
+        # both. This is not an issue for the purpose of this test.
+        path_or_url = str(request.getfixturevalue('schema_file_' + location_type)) + '/datasets.yaml'
+        assert retrieve_schema_file(path_or_url, tls_verification=True) == \
+            (schema_file_relative_dir / 'datasets.yaml').read_text(encoding='utf-8')


### PR DESCRIPTION
This defaults to require a secure link (https with a valid TLS
certificate), but a user has the option to lower the requirements.

Also increase the use of https links instead of http links for our
internal testing purposes, otherwise they would fail for insecure
connection exceptions.

---

## Checklist:

<details open>

<summary></summary>

- Does this pull request close an issue? We encourage you to open an issue first if this pull request (PR) is not a
  minor change.
  - [ ] No
    - [ ] The change in this pull request is minor.
  - [x] Yes
    - Close #internal

For the following questions, only check the boxes that are applicable.

- [x] Ensure that the pull request text above the horizontal line is descriptive.
- [x] Add/update relevant tests.
- [x] Add/update relevant documents.

- Do you have triage permission of this repository?
  - [ ] No
    - You are good.
  - [x] Yes
    - Does this pull request close an issue?
      - [ ] No, this pull request also acts as an issue by itself.
        - [ ] Assign yourself.
        - [ ] Label this pull request.
        - [ ] Put a milestone.
        - [ ] Put this pull request under "In Progress" or "Under Review" pipeline on ZenHub.
        - [ ] Put this pull request under the appropriate epic on ZenHub.
        - [ ] Put an estimate on ZenHub.
        - [ ] Add dependency relationship with other issues/pull requests on ZenHub.
      - [x] Yes, this pull request addresses an issue and does not act as an issue.
        - [x] Connect this pull request to the underlying issue on ZenHub.
        - [x] DON'T:
          - DON'T assign yourself or anyone else.
          - DON'T label.
          - DON'T put a milestone.
          - DON'T put this pull request under any epic on ZenHub.
          - DON'T put an estimate on ZenHub.
    - [x] When the pull request is ready, request review.
</details>
