### PR TITLE
pydax_initialization should localize the download URLs

### DIFF
--- a/pydax/_high_level.py
+++ b/pydax/_high_level.py
@@ -50,7 +50,7 @@ _schemata: Optional[SchemaManager] = None
 
 def init(update_only: bool = True, **kwargs: Any) -> None:
     """
-    (Re-)initialize the PyDAX library. This includes updating PyDAX global configs.
+    (Re-)initialize high-level functions and their configurations.
 
     :param update_only: If ``True``, only update in the global configs what config is specified; reuse schemata loaded
         by high-level functions if URLs do not change. Otherwise, reset everything to default in global configs except

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,7 +203,7 @@ def _download_dataset(dataset_dir, _loaded_schemata) -> Callable[[str], None]:
 
 @pytest.fixture(scope='session')
 def schema_localized_url(_loaded_schemata, _download_dataset, dataset_base_url) -> Callable[[str, str], SchemaDict]:
-    "Utility function fixture for generating schema fixtures with its downloading URL modified to the local HTTP URL."
+    "Utility function fixture for generating schema fixtures with its downloading URL modified to the local HTTPS URL."
     # We use _loaded_schemata instead of loaded_schemata to avoid scope mismatch error (a session-scoped fixture can't
     # call a function-scoped fixture)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,7 +177,10 @@ def dataset_dir() -> Path:
 
 @pytest.fixture(scope='session')
 def _download_dataset(dataset_dir, _loaded_schemata) -> Callable[[str], None]:
-    "Utility function for downloading datasets to ``dataset_dir/{name}-{version}`` for testing purpose."
+    """Utility function for downloading datasets to ``tests/datasets/{name}-{version}`` for testing purpose. These files
+    will not be deleted after the test session terminates, and they are cached for future test sessions. Accordingly, if
+    ``tests/datasets/{name}-{version}`` is already present, this fixture does nothing.
+    """
     # We use _loaded_schemata instead of loaded_schemata to avoid scope mismatch error (a session-scoped fixture can't
     # call a function-scoped fixture)
 
@@ -223,7 +226,8 @@ def _loaded_schemata(schema_file_relative_dir) -> SchemaManager:
     ones used in other schema fixtures, so please do not assume that it is equal to other schema fixtures. One purpose
     of this fixture is to reduce repeated call in the test to the same function when ``loaded_schemata`` is used. The
     other purpose is to provide other session-scoped fixtures access to the loaded schemata, because session-scoped
-    fixtures can't load function-scoped fixtures."""
+    fixtures can't load function-scoped fixtures.
+    """
 
     return SchemaManager(datasets=Schema(schema_file_relative_dir / 'datasets.yaml'),
                          formats=Schema(schema_file_relative_dir / 'formats.yaml'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ import certifi
 import pytest
 
 from pydax import init
+from pydax._high_level import _get_schemata
 from pydax.dataset import Dataset
 from pydax.schema import Schema, SchemaDict, SchemaManager
 
@@ -138,15 +139,21 @@ def untrust_self_signed_cert(local_https_server):
 
 
 @pytest.fixture(autouse=True)
-def pydax_initialization(schema_file_https_url):
+def pydax_initialization(schema_file_https_url, schema_localized_url):
     """Create the default initialization used for all tests. This is mainly for having a uniform initialization for all
     tests as well as avoiding using the actual default schema file URLs so as to decouple the two lines of development
-    (default schema files and this library)."""
+    (default schema files and this library). It also replaces all download URLs with localized URLs."""
 
     init(update_only=False,
          DATASET_SCHEMA_URL=f'{schema_file_https_url}/datasets.yaml',
          FORMAT_SCHEMA_URL=f'{schema_file_https_url}/formats.yaml',
          LICENSE_SCHEMA_URL=f'{schema_file_https_url}/licenses.yaml')
+
+    # Use local dataset locations by default in our tests
+    datasets = _get_schemata().schemata['datasets']._schema['datasets']
+    for name, versions in datasets.items():
+        for version in versions:
+            datasets[name][version] = schema_localized_url(name, version)
 
 # Dataset --------------------------------------
 
@@ -195,25 +202,28 @@ def _download_dataset(dataset_dir, _loaded_schemata) -> Callable[[str], None]:
 
 
 @pytest.fixture(scope='session')
-def _schema(_loaded_schemata, _download_dataset, dataset_base_url) -> Callable[[str, str], SchemaDict]:
-    "Utility function for generating schema fixtures with its downloading URL modified to the local HTTP URL."
+def schema_localized_url(_loaded_schemata, _download_dataset, dataset_base_url) -> Callable[[str, str], SchemaDict]:
+    "Utility function fixture for generating schema fixtures with its downloading URL modified to the local HTTP URL."
     # We use _loaded_schemata instead of loaded_schemata to avoid scope mismatch error (a session-scoped fixture can't
     # call a function-scoped fixture)
 
-    def _schema_impl(name, version):
+    def _schema_localized_url_impl(name, version):
         _download_dataset(name, version)
         schema = _loaded_schemata.schemata['datasets'].export_schema('datasets', name, version)
         schema['download_url'] = str(f'{dataset_base_url}/{name}-{version}')
         return schema
 
-    return _schema_impl
+    return _schema_localized_url_impl
 
 
 @pytest.fixture(scope='session')
 def _loaded_schemata(schema_file_relative_dir) -> SchemaManager:
-    """Loaded schemata, but this should never be modified. One purpose of this fixture is to reduce repeated call in the
-    test to the same function when ``loaded_schemata`` is used. The other purpose is to provide other session-scoped
-    fixtures access to the loaded schemata, because session-scoped fixtures can't load function-scoped fixtures."""
+    """A loaded ``SchemaManager`` object, but this should never be modified. This object manages ``Schema`` objects
+    corresponding to ``tests/{datasets,formats,licenses}.yaml``. Note that these are not necessarily the same as the
+    ones used in other schema fixtures, so please do not assume that it is equal to other schema fixtures. One purpose
+    of this fixture is to reduce repeated call in the test to the same function when ``loaded_schemata`` is used. The
+    other purpose is to provide other session-scoped fixtures access to the loaded schemata, because session-scoped
+    fixtures can't load function-scoped fixtures."""
 
     return SchemaManager(datasets=Schema(schema_file_relative_dir / 'datasets.yaml'),
                          formats=Schema(schema_file_relative_dir / 'formats.yaml'),
@@ -235,8 +245,8 @@ def loaded_schemata(_loaded_schemata) -> SchemaManager:
 # would be easier to understand the error when a test fails.
 
 @pytest.fixture(scope='session')
-def _gmb_schema(_schema):
-    return _schema('gmb', '1.0.2')
+def _gmb_schema(schema_localized_url):
+    return schema_localized_url('gmb', '1.0.2')
 
 
 @pytest.fixture
@@ -245,8 +255,8 @@ def gmb_schema(_gmb_schema):
 
 
 @pytest.fixture(scope='session')
-def _noaa_jfk_schema(_schema):
-    return _schema('noaa_jfk', '1.1.4')
+def _noaa_jfk_schema(schema_localized_url):
+    return schema_localized_url('noaa_jfk', '1.1.4')
 
 
 @pytest.fixture
@@ -255,8 +265,8 @@ def noaa_jfk_schema(_noaa_jfk_schema):
 
 
 @pytest.fixture(scope='session')
-def _wikitext103_schema(_schema):
-    return _schema('wikitext103', '1.0.1')
+def _wikitext103_schema(schema_localized_url):
+    return schema_localized_url('wikitext103', '1.0.1')
 
 
 @pytest.fixture

--- a/tests/test_high_level.py
+++ b/tests/test_high_level.py
@@ -196,12 +196,14 @@ class TestLoadDataset:
 class TestGetDatasetMetadata:
     "Test high-level get_dataset_metadata function."
 
-    def test_human_param(self, loaded_schemata):
+    def test_human_param(self):
+        "Test the ``human`` parameter of ``get_dataset_metadata``."
+
         name, version = 'gmb', '1.0.2'
 
         gmb_metadata = get_dataset_metadata(name, version=version)
-        dataset_schema = loaded_schemata.schemata['datasets'].export_schema('datasets', name, version)
-        license_schema = loaded_schemata.schemata['licenses'].export_schema('licenses')
+        dataset_schema = export_schemata().schemata['datasets'].export_schema('datasets', name, version)
+        license_schema = export_schemata().schemata['licenses'].export_schema('licenses')
         assert gmb_metadata == (f'Dataset name: {dataset_schema["name"]}\n'
                                 f'Description: {dataset_schema["description"]}\n'
                                 f'Size: {dataset_schema["estimated_size"]}\n'
@@ -210,7 +212,7 @@ class TestGetDatasetMetadata:
                                 f'Available subdatasets: {", ".join(dataset_schema["subdatasets"].keys())}')
 
         gmb_schema = get_dataset_metadata(name, version=version, human=False)
-        assert gmb_schema == loaded_schemata.schemata['datasets'].export_schema('datasets', name, version)
+        assert gmb_schema == export_schemata().schemata['datasets'].export_schema('datasets', name, version)
 
 # Schemata --------------------------------------------------
 


### PR DESCRIPTION
This change localizes the URLs in the initialization so that the
reliance on remote hosts is minimized.

After this change, all tests can run without Internet connections after
the first run (which downloads relevant datasets locally). This can
potentially speed up tests if the Internet connections are not very
fast.

---

## Checklist:

<details open>

<summary></summary>

- Does this pull request close an issue? We encourage you to open an issue first if this pull request (PR) is not a
  minor change.
  - [ ] No
    - [ ] The change in this pull request is minor.
  - [x] Yes
    - Close #{internal}

For the following questions, only check the boxes that are applicable.

- [ ] Ensure that the pull request text above the horizontal line is descriptive.
- [ ] Add/update relevant tests.
- [ ] Add/update relevant documents.

- Do you have triage permission of this repository?
  - [ ] No
    - You are good.
  - [x] Yes
    - Does this pull request close an issue?
      - [ ] No, this pull request also acts as an issue by itself.
        - [ ] Assign yourself.
        - [ ] Label this pull request.
        - [ ] Put a milestone.
        - [ ] Put this pull request under "In Progress" or "Under Review" pipeline on ZenHub.
        - [ ] Put this pull request under the appropriate epic on ZenHub.
        - [ ] Put an estimate on ZenHub.
        - [ ] Add dependency relationship with other issues/pull requests on ZenHub.
      - [x] Yes, this pull request addresses an issue and does not act as an issue.
        - [x] Connect this pull request to the underlying issue on ZenHub.
        - [x] DON'T:
          - DON'T assign yourself or anyone else.
          - DON'T label.
          - DON'T put a milestone.
          - DON'T put this pull request under any epic on ZenHub.
          - DON'T put an estimate on ZenHub.
    - [x] When the pull request is ready, request review.
</details>
