### PR TITLE
Each class member method should also have its own doc page

### DIFF
--- a/docs/source/_templates/our-class.rst
+++ b/docs/source/_templates/our-class.rst
@@ -1,0 +1,32 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :show-inheritance:
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in methods %}
+     {% if item != '__init__' %}    {# __init__ is always documented directly under class name #}
+      ~{{ name }}.{{ item }}
+     {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/_templates/our-module.rst
+++ b/docs/source/_templates/our-module.rst
@@ -32,6 +32,7 @@
 
    .. autosummary::
       :toctree:
+      :template: our-class.rst
    {% for item in classes %}
       {{ item }}
    {%- endfor %}
@@ -57,7 +58,7 @@
 .. autosummary::
    :toctree:
    :recursive:
-   :template: our-module
+   :template: our-module.rst
 {% for item in modules %}
    {{ item }}
 {%- endfor %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,6 @@ extensions = [
 
 autosummary_generate = True  # Automate sphinx.ext.autosummary to run when html is generated
 autosummary_imported_members = True  # Imported members should be documented
-autoclass_content = "both"  # Add __init__ doc (ie. params) to class summaries
 autodoc_inherit_docstrings = True  # If no class summary, inherit base class summary
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
For example, methods at https://pydax.readthedocs.io/en/latest/api-references/pydax.dataset.Dataset.html don't have full descriptions.

We do this by overriding the default class template from Sphinx.

Following up #135

---

## Checklist:

<details open>

<summary></summary>

- Does this pull request close an issue? We encourage you to open an issue first if this pull request (PR) is not a
  minor change.
  - [ ] No
    - [ ] The change in this pull request is minor.
  - [x] Yes
    - Close #{internal}

For the following questions, only check the boxes that are applicable.

- [x] Ensure that the pull request text above the horizontal line is descriptive.
- [x] Add/update relevant tests.
- [x] Add/update relevant documents.

- Do you have triage permission of this repository?
  - [ ] No
    - You are good.
  - [x] Yes
    - Does this pull request close an issue?
      - [ ] No, this pull request also acts as an issue by itself.
        - [ ] Assign yourself.
        - [ ] Label this pull request.
        - [ ] Put a milestone.
        - [ ] Put this pull request under "In Progress" or "Under Review" pipeline on ZenHub.
        - [ ] Put this pull request under the appropriate epic on ZenHub.
        - [ ] Put an estimate on ZenHub.
        - [ ] Add dependency relationship with other issues/pull requests on ZenHub.
      - [x] Yes, this pull request addresses an issue and does not act as an issue.
        - [x] Connect this pull request to the underlying issue on ZenHub.
        - [x] DON'T:
          - DON'T assign yourself or anyone else.
          - DON'T label.
          - DON'T put a milestone.
          - DON'T put this pull request under any epic on ZenHub.
          - DON'T put an estimate on ZenHub.
    - [x] When the pull request is ready, request review.
</details>
