### PR TITLE
Remove Ubuntu 16.04 from github actions

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -33,10 +33,10 @@ jobs:
           - os: macos-10.15
             python-version: 3.6
             LC_ALL: en.UTF-8
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             LC_ALL: C
             python-version: 3.6
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             python-version: 3.7
             LC_ALL: en.UTF-8
           - os: ubuntu-18.04


### PR DESCRIPTION
Ubuntu 16.04 has been removed from GitHub actions: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

---

## Checklist:

<details open>

<summary></summary>

- Does this pull request close an issue? We encourage you to open an issue first if this pull request (PR) is not a
  minor change.
  - [x] No
    - [x] The change in this pull request is minor.
  - [ ] Yes
    - Close #{issue_number}

For the following questions, only check the boxes that are applicable.

- [x] Ensure that the pull request text above the horizontal line is descriptive.
- [x] Add/update relevant tests.
- [x] Add/update relevant documents.

- Do you have triage permission of this repository?
  - [ ] No
    - You are good.
  - [x] Yes
    - Does this pull request close an issue?
      - [x] No, this pull request also acts as an issue by itself.
        - [x] Assign yourself.
        - [x] Label this pull request.
        - [x] Put a milestone.
        - [x] Put this pull request under "In Progress" or "Under Review" pipeline on ZenHub.
        - [x] Put this pull request under the appropriate epic on ZenHub.
        - [x] Put an estimate on ZenHub.
        - [x] Add dependency relationship with other issues/pull requests on ZenHub.
      - [ ] Yes, this pull request addresses an issue and does not act as an issue.
        - [ ] Connect this pull request to the underlying issue on ZenHub.
        - [ ] DON'T:
          - DON'T assign yourself or anyone else.
          - DON'T label.
          - DON'T put a milestone.
          - DON'T put this pull request under any epic on ZenHub.
          - DON'T put an estimate on ZenHub.
    - [x] When the pull request is ready, request review.
</details>
